### PR TITLE
Fix #107: Eliminate ghost cursors during rendering operations

### DIFF
--- a/src/repl/controllers/app_controller.rs
+++ b/src/repl/controllers/app_controller.rs
@@ -543,21 +543,19 @@ impl<ES: EventStream, RS: RenderStream> AppController<ES, RS> {
         if needs_full_redraw {
             self.view_renderer.render_full(&self.view_model)?;
         } else {
-            // Selective rendering - hide cursor once at the beginning
+            // Selective rendering - renderer handles cursor visibility
             let has_content_updates = needs_current_area_redraw
                 || needs_secondary_area_redraw
                 || !partial_redraws.is_empty();
             if has_content_updates {
                 tracing::debug!(
-                    "controller: hiding cursor for content updates - current: {}, secondary: {}, partial: {:?}",
+                    "controller: content updates - current: {}, secondary: {}, partial: {:?}",
                     needs_current_area_redraw,
                     needs_secondary_area_redraw,
                     partial_redraws.keys().collect::<Vec<_>>()
                 );
-                // View renderer handles cursor management and flushing
-                // Add a tiny delay to ensure cursor hide command is processed by terminal
-                // This prevents ghost cursors during rapid key repetition
-                std::thread::sleep(std::time::Duration::from_micros(100));
+                // Cursor hiding is now handled by each render method in the renderer
+                // to ensure consistent behavior and prevent ghost cursors
             }
 
             // Render current area if needed

--- a/src/repl/views/terminal_renderer.rs
+++ b/src/repl/views/terminal_renderer.rs
@@ -405,7 +405,8 @@ impl<RS: RenderStream> ViewRenderer for TerminalRenderer<RS> {
     }
 
     fn render_pane(&mut self, view_model: &ViewModel, pane: Pane) -> Result<()> {
-        // Cursor hiding is now handled by the controller
+        // Hide cursor before any rendering to prevent ghost cursors
+        self.render_stream.hide_cursor()?;
 
         let (request_height, response_start, response_height) = view_model
             .pane_manager()
@@ -439,7 +440,8 @@ impl<RS: RenderStream> ViewRenderer for TerminalRenderer<RS> {
         pane: Pane,
         start_line: usize,
     ) -> Result<()> {
-        // Cursor hiding is now handled by the controller
+        // Hide cursor before any rendering to prevent ghost cursors
+        self.render_stream.hide_cursor()?;
 
         let (request_height, response_start, response_height) = view_model
             .pane_manager()

--- a/test_ghost_cursor.sh
+++ b/test_ghost_cursor.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Test script to verify ghost cursor fix
+# This script simulates rapid key presses that previously caused ghost cursors
+
+echo "Testing ghost cursor fix for issue #107"
+echo "Building the application..."
+cargo build --release
+
+echo ""
+echo "Test scenarios:"
+echo "1. Press h,j,k,l rapidly for navigation"
+echo "2. Press w,b,e rapidly for word navigation"  
+echo "3. Type characters rapidly in insert mode"
+echo "4. Use Shift+Left/Right for horizontal scrolling"
+echo "5. Expand/shrink visual selection rapidly with v and movement keys"
+echo ""
+echo "Starting blueline - please test the above scenarios..."
+echo "Press Ctrl+C to exit when done testing"
+
+./target/release/blueline


### PR DESCRIPTION
## Summary
- Fixed ghost cursor artifacts that appeared during rapid key presses and rendering operations
- Ensured proper cursor visibility management across all render methods
- Removed workaround sleep delay that was ineffective

## Changes
- Hide cursor at the start of `render_pane` and `render_pane_partial` methods
- Remove sleep delay workaround from controller
- Let renderer handle all cursor visibility consistently
- Cursor is only shown once at the correct position in `render_cursor`

## Problem Solved
Previously, ghost cursors appeared when:
- Navigation keys (h,j,k,l) were pressed rapidly
- Word navigation keys (w,b,e) were pressed rapidly  
- Characters were inserted quickly in request pane
- Horizontal scrolling with Shift+Left/Right
- Visual selection was expanded/shrunk rapidly

The root cause was inconsistent cursor hiding during rendering operations. Multiple render calls would show/hide the cursor at different positions, creating visual artifacts.

## Test plan
- [x] All existing tests pass
- [x] Pre-commit checks pass (cargo fmt, clippy)
- [x] Created test script `test_ghost_cursor.sh` for manual testing
- [ ] Manual testing: Rapid navigation should not show ghost cursors
- [ ] Manual testing: Rapid text input should not show ghost cursors
- [ ] Manual testing: Visual selection should not show ghost cursors

🤖 Generated with [Claude Code](https://claude.ai/code)