### PR TITLE
Fix #108: Enable ex command during Visual mode

### DIFF
--- a/src/repl/commands/mode.rs
+++ b/src/repl/commands/mode.rs
@@ -105,7 +105,8 @@ pub struct EnterCommandModeCommand;
 impl Command for EnterCommandModeCommand {
     fn is_relevant(&self, context: &CommandContext, event: &KeyEvent) -> bool {
         matches!(event.code, KeyCode::Char(':'))
-            && context.state.current_mode == EditorMode::Normal
+            && (context.state.current_mode == EditorMode::Normal
+                || context.state.current_mode == EditorMode::Visual)
             && event.modifiers.is_empty()
     }
 
@@ -583,5 +584,65 @@ mod tests {
         let result = cmd.execute(event, &context).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], CommandEvent::mode_change(EditorMode::Normal));
+    }
+
+    // EnterCommandModeCommand tests
+    #[test]
+    fn enter_command_mode_should_be_relevant_for_colon_in_normal_mode() {
+        let context = create_test_context();
+        let cmd = EnterCommandModeCommand;
+        let event = create_test_key_event(KeyCode::Char(':'));
+
+        assert!(cmd.is_relevant(&context, &event));
+    }
+
+    #[test]
+    fn enter_command_mode_should_be_relevant_for_colon_in_visual_mode() {
+        let mut context = create_test_context();
+        context.state.current_mode = EditorMode::Visual;
+        let cmd = EnterCommandModeCommand;
+        let event = create_test_key_event(KeyCode::Char(':'));
+
+        assert!(cmd.is_relevant(&context, &event));
+    }
+
+    #[test]
+    fn enter_command_mode_should_not_be_relevant_for_colon_in_insert_mode() {
+        let mut context = create_test_context();
+        context.state.current_mode = EditorMode::Insert;
+        let cmd = EnterCommandModeCommand;
+        let event = create_test_key_event(KeyCode::Char(':'));
+
+        assert!(!cmd.is_relevant(&context, &event));
+    }
+
+    #[test]
+    fn enter_command_mode_should_not_be_relevant_for_colon_in_command_mode() {
+        let mut context = create_test_context();
+        context.state.current_mode = EditorMode::Command;
+        let cmd = EnterCommandModeCommand;
+        let event = create_test_key_event(KeyCode::Char(':'));
+
+        assert!(!cmd.is_relevant(&context, &event));
+    }
+
+    #[test]
+    fn enter_command_mode_should_not_be_relevant_with_modifiers() {
+        let context = create_test_context();
+        let cmd = EnterCommandModeCommand;
+        let event = KeyEvent::new(KeyCode::Char(':'), KeyModifiers::SHIFT);
+
+        assert!(!cmd.is_relevant(&context, &event));
+    }
+
+    #[test]
+    fn enter_command_mode_should_produce_command_mode_change_event() {
+        let context = create_test_context();
+        let cmd = EnterCommandModeCommand;
+        let event = create_test_key_event(KeyCode::Char(':'));
+
+        let result = cmd.execute(event, &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], CommandEvent::mode_change(EditorMode::Command));
     }
 }


### PR DESCRIPTION
## Summary
- Allow pressing ':' to enter command mode when in Visual mode, not just Normal mode
- This enables standard vim behavior where ex commands can be used from visual mode
- Fixes issue #108

## Changes Made
- Modified `EnterCommandModeCommand.is_relevant()` to accept both Normal and Visual modes
- Added comprehensive tests for all mode combinations
- Maintained backward compatibility with existing Normal mode behavior

## Test Plan
- [x] All existing tests pass
- [x] Added 6 new tests covering all mode combinations:
  - ✅ Works in Normal mode (existing behavior)
  - ✅ Works in Visual mode (new behavior)
  - ✅ Doesn't work in Insert mode
  - ✅ Doesn't work in Command mode
  - ✅ Doesn't work with modifier keys
  - ✅ Produces correct command mode change event
- [x] Pre-commit checks pass (cargo fmt, clippy)
- [x] Binary builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)