### PR TITLE
Fix #126: Replace println/eprintln with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blueline"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "bluenote",

--- a/src/repl/models/display_line.rs
+++ b/src/repl/models/display_line.rs
@@ -338,7 +338,9 @@ impl DisplayLine {
             }
         }
 
-        tracing::debug!("find_next_word_end: no unicode-segmentation word boundaries found, trying fallback");
+        tracing::debug!(
+            "find_next_word_end: no unicode-segmentation word boundaries found, trying fallback"
+        );
 
         // FALLBACK: Implement vim 'e' behavior with character-based detection
         // Vim 'e' behavior:

--- a/src/repl/text/word_segmenter.rs
+++ b/src/repl/text/word_segmenter.rs
@@ -262,8 +262,8 @@ mod tests {
         let boundaries = segmenter.find_word_boundaries("Hello World").unwrap();
 
         // Debug: Print what we got
-        println!("Text: 'Hello World'");
-        println!("Boundaries: {:?}", boundaries.positions);
+        tracing::debug!("Text: 'Hello World'");
+        tracing::debug!("Boundaries: {:?}", boundaries.positions);
 
         // Unicode-segmentation should give us word boundaries
         assert!(!boundaries.positions.is_empty());
@@ -280,7 +280,7 @@ mod tests {
         // Debug: Print the flags
         for (i, flag) in flags.iter().enumerate() {
             if flag.is_word_start || flag.is_word_end {
-                println!("Position {i}: {flag:?}");
+                tracing::debug!("Position {i}: {flag:?}");
             }
         }
 
@@ -288,7 +288,7 @@ mod tests {
         let has_word_starts = flags.iter().any(|flag| flag.is_word_start);
         let has_word_ends = flags.iter().any(|flag| flag.is_word_end);
 
-        println!("Has word starts: {has_word_starts}, Has word ends: {has_word_ends}");
+        tracing::debug!("Has word starts: {has_word_starts}, Has word ends: {has_word_ends}");
     }
 
     #[test]
@@ -379,18 +379,18 @@ mod tests {
         ];
 
         for (text, description) in test_cases {
-            println!("\n=== {description} ===");
-            println!("Text: '{text}'");
+            tracing::debug!("\n=== {description} ===");
+            tracing::debug!("Text: '{text}'");
 
             let boundaries = segmenter.find_word_boundaries(text).unwrap();
-            println!("Boundaries: {:?}", boundaries.positions);
+            tracing::debug!("Boundaries: {:?}", boundaries.positions);
 
             // Verify boundaries point to valid character starts
             for &pos in &boundaries.positions {
                 if pos < text.len() {
                     let slice = &text[pos..];
                     let first_char = slice.chars().next().unwrap();
-                    println!("  Byte {pos} -> '{first_char}'");
+                    tracing::debug!("  Byte {pos} -> '{first_char}'");
                 }
             }
         }

--- a/tests/common/debug_test.rs
+++ b/tests/common/debug_test.rs
@@ -5,18 +5,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_spawn() -> Result<()> {
-        println!("Testing basic tokio::spawn...");
+        tracing::debug!("Testing basic tokio::spawn...");
 
         let task = tokio::spawn(async {
-            println!("Inside spawned task");
+            tracing::debug!("Inside spawned task");
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            println!("Spawned task complete");
+            tracing::debug!("Spawned task complete");
             42
         });
 
-        println!("Waiting for spawned task...");
+        tracing::debug!("Waiting for spawned task...");
         let result = task.await.expect("Task failed");
-        println!("Got result: {result}");
+        tracing::debug!("Got result: {result}");
 
         Ok(())
     }
@@ -27,33 +27,33 @@ mod tests {
         use blueline::repl::controllers::app_controller::AppController;
         use blueline::repl::io::test_bridge::{BridgedEventStream, BridgedRenderStream};
 
-        println!("1. Testing bridge creation...");
+        tracing::info!("1. Testing bridge creation...");
         let (event_stream, _controller) = BridgedEventStream::new();
         let (render_stream, _monitor) = BridgedRenderStream::new((80, 24));
-        println!("✅ Bridge created");
+        tracing::info!("✅ Bridge created");
 
-        println!("2. Testing command args...");
+        tracing::info!("2. Testing command args...");
         let cmd_args = CommandLineArgs::parse_from(vec!["blueline".to_string()]);
-        println!("✅ Command args parsed");
+        tracing::info!("✅ Command args parsed");
 
-        println!("3. Testing AppController creation...");
+        tracing::info!("3. Testing AppController creation...");
         let app_result = AppController::with_io_streams(cmd_args, event_stream, render_stream);
         match app_result {
             Ok(_app) => {
-                println!("✅ AppController created successfully!");
-                println!("4. Skipping app.run() test to avoid hanging - creation test complete!");
+                tracing::info!("✅ AppController created successfully!");
+                tracing::info!("4. Skipping app.run() test to avoid hanging - creation test complete!");
 
                 // For now, just test that we can create the AppController successfully
                 // The app.run() method blocks indefinitely waiting for events, which is expected behavior
                 // In real usage, it would be terminated by Ctrl+C or other quit signals
             }
             Err(e) => {
-                println!("❌ AppController creation failed: {e}");
+                tracing::error!("❌ AppController creation failed: {e}");
                 return Err(e);
             }
         }
 
-        println!("SUCCESS: AppController creation works!");
+        tracing::info!("SUCCESS: AppController creation works!");
         Ok(())
     }
 }

--- a/tests/common/world.rs
+++ b/tests/common/world.rs
@@ -449,11 +449,11 @@ impl BluelineWorld {
 
         // Special check for John issue
         if text.contains("John") {
-            eprintln!(
+            tracing::debug!(
                 "🔍 JOHN DEBUG - About to type 'name: John' in mode: {:?}",
                 self.current_mode
             );
-            eprintln!(
+            tracing::debug!(
                 "🔍 JOHN DEBUG - Text buffer BEFORE typing: {:?}",
                 self.text_buffer
             );
@@ -508,15 +508,15 @@ impl BluelineWorld {
                     // Double-check that John is actually in the text buffer
                     let has_john = self.text_buffer.iter().any(|line| line.contains("John"));
                     if !has_john {
-                        eprintln!(
+                        tracing::debug!(
                             "⚠️ JOHN DEBUG - ERROR: John not found in text buffer after adding!"
                         );
-                        eprintln!("⚠️ JOHN DEBUG - Text buffer state: {:?}", self.text_buffer);
+                        tracing::debug!("⚠️ JOHN DEBUG - Text buffer state: {:?}", self.text_buffer);
                         // Force add it as a failsafe
                         if let Some(last_line) = self.text_buffer.last_mut() {
                             if last_line.is_empty() {
                                 *last_line = text.to_string();
-                                eprintln!("⚠️ JOHN DEBUG - Forcefully added John to last line");
+                                tracing::debug!("⚠️ JOHN DEBUG - Forcefully added John to last line");
                             }
                         }
                     }

--- a/tests/steps/command_line.rs
+++ b/tests/steps/command_line.rs
@@ -93,10 +93,10 @@ async fn then_status_bar_is_cleared(world: &mut BluelineWorld) {
         || world.terminal_contains("error").await;
 
     if !has_default_status {
-        eprintln!("❌ Default REQUEST status not found. Terminal content:\n{terminal_content}");
+        tracing::debug!("❌ Default REQUEST status not found. Terminal content:\n{terminal_content}");
         // Check if terminal content is empty or has different format
         if terminal_content.trim().is_empty() {
-            eprintln!("💡 Terminal appears to be empty - possible test framework issue");
+            tracing::debug!("💡 Terminal appears to be empty - possible test framework issue");
         }
     }
 
@@ -163,15 +163,15 @@ async fn then_cursor_should_be_at_line_n(world: &mut BluelineWorld, line_num: us
     let found_indicator = contains_colon || contains_pipe || contains_request;
 
     if !found_indicator {
-        eprintln!("❌ Line navigation failed!");
-        eprintln!("Expected line: {line_num}");
-        eprintln!("Terminal content ({} chars):", terminal_content.len());
-        eprintln!("=== FULL TERMINAL CONTENT ===");
+        tracing::debug!("❌ Line navigation failed!");
+        tracing::debug!("Expected line: {line_num}");
+        tracing::debug!("Terminal content ({} chars):", terminal_content.len());
+        tracing::debug!("=== FULL TERMINAL CONTENT ===");
         for (i, line) in terminal_content.lines().enumerate() {
-            eprintln!("{:2}: '{}'", i + 1, line);
+            tracing::debug!("{:2}: '{}'", i + 1, line);
         }
-        eprintln!("=== END TERMINAL CONTENT ===");
-        eprintln!(
+        tracing::debug!("=== END TERMINAL CONTENT ===");
+        tracing::debug!(
             "Cursor position: ({}, {})",
             state.cursor_position.0, state.cursor_position.1
         );
@@ -179,7 +179,7 @@ async fn then_cursor_should_be_at_line_n(world: &mut BluelineWorld, line_num: us
         // Also check if any number appears in the terminal
         for i in 1..=10 {
             if terminal_content.contains(&i.to_string()) {
-                eprintln!("Found number '{i}' in terminal content");
+                tracing::debug!("Found number '{i}' in terminal content");
             }
         }
     }

--- a/tests/steps/http.rs
+++ b/tests/steps/http.rs
@@ -92,31 +92,31 @@ async fn then_should_see_in_request_pane(world: &mut BluelineWorld, text: String
 
     // Special handling for doublebyte character tests
     if !contains && text.chars().any(|c| c as u32 > 127) {
-        eprintln!("❌ Doublebyte text not found!");
-        eprintln!("Looking for: '{text}'");
-        eprintln!("Terminal content ({} chars):", terminal_content.len());
+        tracing::debug!("❌ Doublebyte text not found!");
+        tracing::debug!("Looking for: '{text}'");
+        tracing::debug!("Terminal content ({} chars):", terminal_content.len());
 
         // Check if any doublebyte characters are in the terminal at all
         let has_doublebyte = terminal_content.chars().any(|c| c as u32 > 127);
-        eprintln!("Terminal contains doublebyte characters: {has_doublebyte}");
+        tracing::debug!("Terminal contains doublebyte characters: {has_doublebyte}");
 
         if has_doublebyte {
-            eprintln!("=== TERMINAL CONTENT WITH DOUBLEBYTE ===");
+            tracing::debug!("=== TERMINAL CONTENT WITH DOUBLEBYTE ===");
             for (i, line) in terminal_content.lines().enumerate() {
-                eprintln!("{:2}: '{}'", i + 1, line);
+                tracing::debug!("{:2}: '{}'", i + 1, line);
                 // Show character codes for debugging
                 for (j, ch) in line.chars().enumerate() {
                     if ch as u32 > 127 {
-                        eprintln!("    [{:2}]: '{}' (U+{:04X})", j, ch, ch as u32);
+                        tracing::debug!("    [{:2}]: '{}' (U+{:04X})", j, ch, ch as u32);
                     }
                 }
             }
-            eprintln!("=== END TERMINAL CONTENT ===");
+            tracing::debug!("=== END TERMINAL CONTENT ===");
         } else {
-            eprintln!(
+            tracing::debug!(
                 "💡 No doublebyte characters found - possible encoding/rendering issue in test"
             );
-            eprintln!(
+            tracing::debug!(
                 "First 200 chars: '{}'",
                 &terminal_content.chars().take(200).collect::<String>()
             );
@@ -191,7 +191,7 @@ async fn then_in_response_pane(world: &mut BluelineWorld) {
         || world.terminal_contains("RESPONSE").await;
 
     if !in_response {
-        eprintln!("❌ Response pane indicators not found. Terminal content:\n{terminal_content}");
+        tracing::debug!("❌ Response pane indicators not found. Terminal content:\n{terminal_content}");
 
         // Check if this might be because there's no actual response content
         let has_response_content = world.terminal_contains("200").await
@@ -200,19 +200,19 @@ async fn then_in_response_pane(world: &mut BluelineWorld) {
             || world.terminal_contains("│").await;
 
         if !has_response_content {
-            eprintln!("💡 No response content detected - Tab navigation may not work without actual HTTP response");
+            tracing::debug!("💡 No response content detected - Tab navigation may not work without actual HTTP response");
         }
 
         // Check if we can find REQUEST pane indicator instead
         let in_request = world.terminal_contains("REQUEST").await;
-        eprintln!("🔍 Found REQUEST pane indicator: {in_request}");
+        tracing::debug!("🔍 Found REQUEST pane indicator: {in_request}");
 
         // Show terminal content line by line for debugging
-        eprintln!("=== FULL TERMINAL CONTENT ===");
+        tracing::debug!("=== FULL TERMINAL CONTENT ===");
         for (i, line) in terminal_content.lines().enumerate() {
-            eprintln!("{:2}: '{}'", i + 1, line);
+            tracing::debug!("{:2}: '{}'", i + 1, line);
         }
-        eprintln!("=== END TERMINAL CONTENT ===");
+        tracing::debug!("=== END TERMINAL CONTENT ===");
     }
 
     // In test environment, Tab navigation might not work without actual HTTP response

--- a/tests/steps/text_manipulation.rs
+++ b/tests/steps/text_manipulation.rs
@@ -24,7 +24,7 @@ async fn when_type_text(world: &mut BluelineWorld, text: String) {
 
     // Special debugging for John issue
     if text.contains("John") {
-        eprintln!(
+        tracing::debug!(
             "🔍 ABOUT TO TYPE: '{}', text buffer before: {:?}",
             text,
             world.get_text_buffer()
@@ -37,7 +37,7 @@ async fn when_type_text(world: &mut BluelineWorld, text: String) {
 
     // Check text buffer after typing John
     if text.contains("John") {
-        eprintln!(
+        tracing::debug!(
             "🔍 AFTER TYPING: '{}', text buffer after: {:?}",
             text,
             world.get_text_buffer()
@@ -58,7 +58,7 @@ async fn then_should_see_output(world: &mut BluelineWorld, expected_output: Stri
     // Debug output for John issue (now that we've fixed it)
     if expected_output == "John" && !contains {
         let text_buffer = world.get_text_buffer();
-        eprintln!(
+        tracing::debug!(
             "🔍 JOHN DEBUG - Text not found!\n\
             Expected: '{}'\n\
             Terminal content ({} chars):\n'{}'\n\
@@ -287,13 +287,13 @@ async fn then_text_becomes(world: &mut BluelineWorld, step: &gherkin::Step) {
 
     // Debug: show actual terminal content
     let terminal_content = world.get_terminal_content().await;
-    eprintln!("=== EXPECTED TEXT ===");
-    eprintln!("'{expected}'");
-    eprintln!("=== ACTUAL TERMINAL CONTENT ===");
+    tracing::debug!("=== EXPECTED TEXT ===");
+    tracing::debug!("'{expected}'");
+    tracing::debug!("=== ACTUAL TERMINAL CONTENT ===");
     for (i, line) in terminal_content.lines().enumerate() {
-        eprintln!("{:2}: '{}'", i + 1, line);
+        tracing::debug!("{:2}: '{}'", i + 1, line);
     }
-    eprintln!("=== END COMPARISON ===");
+    tracing::debug!("=== END COMPARISON ===");
 
     // Check each line of the expected text
     for line in expected.lines() {
@@ -301,8 +301,8 @@ async fn then_text_becomes(world: &mut BluelineWorld, step: &gherkin::Step) {
             // Skip empty lines
             let contains = world.terminal_contains(line).await;
             if !contains {
-                eprintln!("❌ Missing line: '{line}'");
-                eprintln!(
+                tracing::debug!("❌ Missing line: '{line}'");
+                tracing::debug!(
                     "Terminal content: '{}'",
                     terminal_content.replace('\n', "\\n")
                 );

--- a/tests/steps/window.rs
+++ b/tests/steps/window.rs
@@ -117,8 +117,8 @@ async fn then_request_pane_highlighted(world: &mut BluelineWorld) {
             "Terminal content for focus check: {}",
             terminal_content.replace('\n', "\\n")
         );
-        eprintln!("💡 No specific focus indicator found - checking for basic pane presence");
-        eprintln!(
+        tracing::debug!("💡 No specific focus indicator found - checking for basic pane presence");
+        tracing::debug!(
             "Terminal content: '{}'",
             terminal_content
                 .lines()
@@ -149,8 +149,8 @@ async fn then_response_pane_highlighted(world: &mut BluelineWorld) {
             "Terminal content for Response focus check: {}",
             terminal_content.replace('\n', "\\n")
         );
-        eprintln!("💡 No specific Response focus indicator found");
-        eprintln!(
+        tracing::debug!("💡 No specific Response focus indicator found");
+        tracing::debug!(
             "Terminal content: '{}'",
             terminal_content
                 .lines()
@@ -167,7 +167,7 @@ async fn then_response_pane_highlighted(world: &mut BluelineWorld) {
             || world.terminal_contains("│").await;
 
         if !has_response_content {
-            eprintln!("💡 No response content detected - Response pane focus may not work without actual HTTP response");
+            tracing::debug!("💡 No response content detected - Response pane focus may not work without actual HTTP response");
             // For test environment, just verify we have some pane indicator
             let has_any_pane = world.terminal_contains("REQUEST").await
                 || world.terminal_contains("RESPONSE").await;
@@ -198,8 +198,8 @@ async fn then_request_pane_not_highlighted(world: &mut BluelineWorld) {
             "Terminal content for Request unfocus check: {}",
             terminal_content.replace('\n', "\\n")
         );
-        eprintln!("💡 No Response focus indicator found after Tab navigation");
-        eprintln!(
+        tracing::debug!("💡 No Response focus indicator found after Tab navigation");
+        tracing::debug!(
             "Terminal content: '{}'",
             terminal_content
                 .lines()
@@ -216,7 +216,7 @@ async fn then_request_pane_not_highlighted(world: &mut BluelineWorld) {
             || world.terminal_contains("│").await;
 
         if !has_response_content {
-            eprintln!("💡 No response content detected - Response pane focus may not work without actual HTTP response");
+            tracing::debug!("💡 No response content detected - Response pane focus may not work without actual HTTP response");
             // For test environment, just verify we have some pane indicator and Tab was processed
             let has_any_pane = world.terminal_contains("REQUEST").await
                 || world.terminal_contains("RESPONSE").await;
@@ -228,7 +228,7 @@ async fn then_request_pane_not_highlighted(world: &mut BluelineWorld) {
         }
 
         // If we have response content but no focus indicator, be more lenient
-        eprintln!("💡 Response content exists but focus indicator not detected - test environment limitation");
+        tracing::debug!("💡 Response content exists but focus indicator not detected - test environment limitation");
         let has_any_pane =
             world.terminal_contains("REQUEST").await || world.terminal_contains("RESPONSE").await;
         assert!(has_any_pane, "Should have some pane indicator");


### PR DESCRIPTION
## Summary
- Replaced all `println\!` and `eprintln\!` statements with appropriate `tracing` calls throughout the codebase
- Ensures consistent logging approach as per TEST_RULES.md requirement #6

## Changes Made
- Updated `src/repl/text/word_segmenter.rs` - replaced `println\!` with `tracing::debug\!`
- Updated `tests/common/debug_test.rs` - replaced `println\!` with context-appropriate tracing levels (`info\!`, `debug\!`, `error\!`)
- Bulk replaced `eprintln\!` with `tracing::debug\!` in all test step files:
  - `tests/steps/http.rs`
  - `tests/steps/text_manipulation.rs`
  - `tests/steps/window.rs`
  - `tests/steps/command_line.rs`
  - `tests/common/world.rs`

## Test Results
All tests pass successfully (313 passed, 0 failed, 1 ignored)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>