### PR TITLE
Fix #64: Introduce Command Pattern to ex commands

### DIFF
--- a/src/repl/commands/events.rs
+++ b/src/repl/commands/events.rs
@@ -9,6 +9,24 @@ use crate::repl::events::{EditorMode, LogicalPosition, Pane};
 /// Type alias for HTTP headers to reduce complexity
 pub type HttpHeaders = Vec<(String, String)>;
 
+/// Available settings that can be changed
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Setting {
+    /// Line wrapping setting
+    Wrap,
+    /// Line numbers display setting
+    LineNumbers,
+}
+
+/// Values for settings
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingValue {
+    /// Enable the setting
+    On,
+    /// Disable the setting
+    Off,
+}
+
 /// Events that commands can produce to request changes
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandEvent {
@@ -68,6 +86,12 @@ pub enum CommandEvent {
 
     /// Request to show profile information in status bar
     ShowProfileRequested,
+
+    /// Request to change a setting (wrap, line numbers, etc.)
+    SettingChangeRequested {
+        setting: Setting,
+        value: SettingValue,
+    },
 
     /// No action needed (for commands that only query state)
     NoAction,

--- a/src/repl/commands/ex_commands.rs
+++ b/src/repl/commands/ex_commands.rs
@@ -1,0 +1,297 @@
+//! # Ex Commands Module
+//!
+//! Implementation of ex commands (colon commands) using the command pattern.
+//! This provides a unified event-driven approach for both normal and ex commands.
+
+use anyhow::Result;
+
+use crate::repl::commands::{
+    CommandContext, CommandEvent, MovementDirection, Setting, SettingValue,
+};
+
+/// Trait for ex commands
+pub trait ExCommand: Send {
+    /// Parse and check if this command can handle the given ex command string
+    fn can_handle(&self, command: &str) -> bool;
+
+    /// Execute the ex command and produce events
+    fn execute(&self, command: &str, context: &CommandContext) -> Result<Vec<CommandEvent>>;
+
+    /// Get command name for debugging
+    fn name(&self) -> &'static str;
+}
+
+/// Quit command handler (for :q and :q!)
+pub struct QuitCommand;
+
+impl ExCommand for QuitCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        command == "q" || command == "q!"
+    }
+
+    fn execute(&self, _command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        Ok(vec![CommandEvent::QuitRequested])
+    }
+
+    fn name(&self) -> &'static str {
+        "QuitCommand"
+    }
+}
+
+/// Set wrap command handler (for :set wrap on/off)
+pub struct SetWrapCommand;
+
+impl ExCommand for SetWrapCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        command == "set wrap on" || command == "set wrap off"
+    }
+
+    fn execute(&self, command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        let enable = command == "set wrap on";
+
+        // For now, we'll create a new event type for settings changes
+        // This will be handled by the controller
+        Ok(vec![CommandEvent::SettingChangeRequested {
+            setting: Setting::Wrap,
+            value: if enable {
+                SettingValue::On
+            } else {
+                SettingValue::Off
+            },
+        }])
+    }
+
+    fn name(&self) -> &'static str {
+        "SetWrapCommand"
+    }
+}
+
+/// Set line numbers command handler (for :set number on/off)
+pub struct SetNumberCommand;
+
+impl ExCommand for SetNumberCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        command == "set number on" || command == "set number off"
+    }
+
+    fn execute(&self, command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        let enable = command == "set number on";
+
+        Ok(vec![CommandEvent::SettingChangeRequested {
+            setting: Setting::LineNumbers,
+            value: if enable {
+                SettingValue::On
+            } else {
+                SettingValue::Off
+            },
+        }])
+    }
+
+    fn name(&self) -> &'static str {
+        "SetNumberCommand"
+    }
+}
+
+/// Show profile command handler (for :show profile)
+pub struct ShowProfileCommand;
+
+impl ExCommand for ShowProfileCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        command == "show profile"
+    }
+
+    fn execute(&self, _command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        Ok(vec![CommandEvent::ShowProfileRequested])
+    }
+
+    fn name(&self) -> &'static str {
+        "ShowProfileCommand"
+    }
+}
+
+/// Type alias to reduce complexity for ex command collection
+type ExCommandCollection = Vec<Box<dyn ExCommand + Send>>;
+
+/// Go to line command handler (for :<number>)
+pub struct GoToLineCommand;
+
+impl ExCommand for GoToLineCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        // Check if it's a valid line number
+        command.parse::<usize>().is_ok()
+    }
+
+    fn execute(&self, command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        if let Ok(line_number) = command.parse::<usize>() {
+            if line_number > 0 {
+                Ok(vec![CommandEvent::CursorMoveRequested {
+                    direction: MovementDirection::LineNumber(line_number),
+                    amount: 1,
+                }])
+            } else {
+                tracing::warn!("Invalid line number: {}", line_number);
+                Ok(vec![])
+            }
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "GoToLineCommand"
+    }
+}
+
+/// Registry for managing ex commands
+pub struct ExCommandRegistry {
+    commands: ExCommandCollection,
+}
+
+impl ExCommandRegistry {
+    /// Create a new ex command registry with all default commands
+    pub fn new() -> Self {
+        let commands: ExCommandCollection = vec![
+            Box::new(QuitCommand),
+            Box::new(SetWrapCommand),
+            Box::new(SetNumberCommand),
+            Box::new(ShowProfileCommand),
+            Box::new(GoToLineCommand),
+        ];
+
+        Self { commands }
+    }
+
+    /// Parse and execute an ex command string
+    pub fn execute_command(
+        &self,
+        command_str: &str,
+        context: &CommandContext,
+    ) -> Result<Vec<CommandEvent>> {
+        let trimmed = command_str.trim();
+
+        // Empty command just exits command mode
+        if trimmed.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Find the first command that can handle this string
+        for command in &self.commands {
+            if command.can_handle(trimmed) {
+                tracing::debug!("Ex command '{}' handled by {}", trimmed, command.name());
+                return command.execute(trimmed, context);
+            }
+        }
+
+        // Unknown command
+        tracing::warn!("Unknown ex command: {}", trimmed);
+        Ok(vec![])
+    }
+}
+
+impl Default for ExCommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::commands::ViewModelSnapshot;
+    use crate::repl::events::{EditorMode, LogicalPosition, Pane};
+
+    fn create_test_context() -> CommandContext {
+        CommandContext {
+            state: ViewModelSnapshot {
+                current_mode: EditorMode::Normal,
+                current_pane: Pane::Request,
+                cursor_position: LogicalPosition::zero(),
+                request_text: String::new(),
+                response_text: String::new(),
+                terminal_dimensions: (80, 24),
+                verbose: false,
+            },
+        }
+    }
+
+    #[test]
+    fn quit_command_should_handle_q() {
+        let cmd = QuitCommand;
+        assert!(cmd.can_handle("q"));
+        assert!(cmd.can_handle("q!"));
+        assert!(!cmd.can_handle("quit"));
+    }
+
+    #[test]
+    fn quit_command_should_produce_quit_event() {
+        let cmd = QuitCommand;
+        let context = create_test_context();
+        let result = cmd.execute("q", &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], CommandEvent::QuitRequested);
+    }
+
+    #[test]
+    fn set_wrap_command_should_handle_wrap_settings() {
+        let cmd = SetWrapCommand;
+        assert!(cmd.can_handle("set wrap on"));
+        assert!(cmd.can_handle("set wrap off"));
+        assert!(!cmd.can_handle("set wrap"));
+    }
+
+    #[test]
+    fn goto_line_command_should_handle_numbers() {
+        let cmd = GoToLineCommand;
+        assert!(cmd.can_handle("42"));
+        assert!(cmd.can_handle("1"));
+        assert!(!cmd.can_handle("abc"));
+        assert!(!cmd.can_handle(""));
+    }
+
+    #[test]
+    fn goto_line_command_should_produce_cursor_move_event() {
+        let cmd = GoToLineCommand;
+        let context = create_test_context();
+        let result = cmd.execute("58", &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            CommandEvent::CursorMoveRequested {
+                direction: MovementDirection::LineNumber(58),
+                amount: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn registry_should_execute_known_commands() {
+        let registry = ExCommandRegistry::new();
+        let context = create_test_context();
+
+        let result = registry.execute_command("q", &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], CommandEvent::QuitRequested);
+
+        let result = registry.execute_command("show profile", &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], CommandEvent::ShowProfileRequested);
+    }
+
+    #[test]
+    fn registry_should_handle_unknown_commands() {
+        let registry = ExCommandRegistry::new();
+        let context = create_test_context();
+
+        let result = registry.execute_command("unknown", &context).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn registry_should_handle_empty_command() {
+        let registry = ExCommandRegistry::new();
+        let context = create_test_context();
+
+        let result = registry.execute_command("", &context).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+}

--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -42,6 +42,7 @@ pub trait HttpCommand: Send {
 // Import command modules
 pub mod app;
 pub mod editing;
+pub mod ex_commands;
 pub mod mode;
 pub mod navigation;
 pub mod pane;
@@ -52,6 +53,7 @@ pub use app::AppTerminateCommand;
 pub use editing::{
     DeleteCharAtCursorCommand, DeleteCharCommand, InsertCharCommand, InsertNewLineCommand,
 };
+pub use ex_commands::{ExCommand, ExCommandRegistry};
 pub use mode::{
     AppendAfterCursorCommand, AppendAtEndOfLineCommand, EnterCommandModeCommand,
     EnterInsertModeCommand, EnterVisualModeCommand, ExCommandModeCommand, ExitInsertModeCommand,

--- a/src/repl/view_models/ex_command_manager.rs
+++ b/src/repl/view_models/ex_command_manager.rs
@@ -27,6 +27,12 @@ impl ViewModel {
         Ok(())
     }
 
+    /// Clear the ex command buffer
+    pub fn clear_ex_command_buffer(&mut self) {
+        self.status_line.clear_command_buffer();
+        let _ = self.emit_view_event([ViewEvent::StatusBarUpdateRequired]);
+    }
+
     /// Execute ex command and return resulting command events
     pub fn execute_ex_command(&mut self) -> Result<Vec<CommandEvent>> {
         let command = self.status_line.command_buffer().trim().to_string();

--- a/src/repl/view_models/mod.rs
+++ b/src/repl/view_models/mod.rs
@@ -14,6 +14,7 @@ mod pane_manager;
 mod pane_state;
 mod rendering_coordinator;
 mod screen_buffer;
+mod settings_manager;
 
 // Re-export the main ViewModel
 pub use core::ViewModel;

--- a/src/repl/view_models/settings_manager.rs
+++ b/src/repl/view_models/settings_manager.rs
@@ -1,0 +1,34 @@
+//! # Settings Management
+//!
+//! Handles settings changes from ex commands.
+
+use crate::repl::commands::{Setting, SettingValue};
+use crate::repl::events::ViewEvent;
+use crate::repl::view_models::core::ViewModel;
+use anyhow::Result;
+
+impl ViewModel {
+    /// Apply a setting change from an ex command
+    pub fn apply_setting(&mut self, setting: Setting, value: SettingValue) -> Result<()> {
+        match setting {
+            Setting::Wrap => {
+                let enable = value == SettingValue::On;
+                self.pane_manager.set_wrap_enabled(enable);
+                let visibility_events = self.pane_manager.rebuild_display_caches_and_sync();
+                let mut events = vec![ViewEvent::FullRedrawRequired];
+                events.extend(visibility_events);
+                let _ = self.emit_view_event(events);
+                Ok(())
+            }
+            Setting::LineNumbers => {
+                let enable = value == SettingValue::On;
+                self.pane_manager.set_line_numbers_visible(enable);
+                let visibility_events = self.pane_manager.rebuild_display_caches_and_sync();
+                let mut events = vec![ViewEvent::FullRedrawRequired];
+                events.extend(visibility_events);
+                let _ = self.emit_view_event(events);
+                Ok(())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the Command Pattern to ex commands, unifying the command handling architecture across normal and ex commands. The refactoring removes command execution logic from StatusLine, allowing it to focus solely on display management.

## Key Changes

- **New Ex Command Infrastructure**: Created `ExCommand` trait and `ExCommandRegistry` for managing ex commands
- **Individual Command Implementations**: Implemented separate command structs for each ex command:
  - `QuitCommand` (`:q` and `:q\!`)
  - `SetWrapCommand` (`:set wrap on/off`)
  - `SetNumberCommand` (`:set number on/off`)
  - `ShowProfileCommand` (`:show profile`)
  - `GoToLineCommand` (`:number` navigation)
- **Event-Driven Architecture**: Added `SettingChangeRequested` event with proper enums for type-safe settings management
- **Improved UX**: Ex command buffer is now properly cleared and mode returns to previous state after command execution

## Benefits

✅ **Unified Architecture**: Ex commands now use the same event-driven pattern as normal commands
✅ **Separation of Concerns**: StatusLine no longer handles command execution logic
✅ **Extensibility**: Easy to add new ex commands by implementing the `ExCommand` trait
✅ **Maintainability**: Command logic is now modular and independently testable
✅ **Better UX**: Command line properly clears after execution

## Test Results

- All unit tests pass ✅
- All integration tests pass ✅
- Precheck script passes ✅
- No clippy warnings ✅

## Related Issue

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)