### PR TITLE
Fix #151: Implement simple tab character support

### DIFF
--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -53,6 +53,7 @@ pub mod yank;
 pub use app::AppTerminateCommand;
 pub use editing::{
     DeleteCharAtCursorCommand, DeleteCharCommand, InsertCharCommand, InsertNewLineCommand,
+    InsertTabCommand,
 };
 pub use ex_commands::{ExCommand, ExCommandRegistry};
 pub use mode::{
@@ -126,6 +127,7 @@ impl CommandRegistry {
             // Editing commands
             Box::new(InsertCharCommand),
             Box::new(InsertNewLineCommand),
+            Box::new(InsertTabCommand),
             Box::new(DeleteCharCommand),
             Box::new(DeleteCharAtCursorCommand),
             Box::new(YankCommand),

--- a/src/repl/models/buffer_model.rs
+++ b/src/repl/models/buffer_model.rs
@@ -763,4 +763,32 @@ mod tests {
         assert!(event.is_some());
         assert_eq!(buffer.cursor(), LogicalPosition::new(0, 10)); // End of "こんにちは"
     }
+
+    #[test]
+    fn buffer_model_cursor_position_after_tab_insertion() {
+        let mut buffer = BufferModel::new(Pane::Request);
+
+        // Insert "TEST"
+        buffer.insert_text("TEST");
+        let cursor_after_test = buffer.cursor();
+        println!("Cursor after 'TEST': {cursor_after_test:?}");
+        assert_eq!(cursor_after_test, LogicalPosition::new(0, 4));
+
+        // Insert tab
+        buffer.insert_text("\t");
+        let cursor_after_tab = buffer.cursor();
+        println!("Cursor after tab: {cursor_after_tab:?}");
+        assert_eq!(cursor_after_tab, LogicalPosition::new(0, 5));
+
+        // Insert "TEST"
+        buffer.insert_text("TEST");
+        let cursor_after_second_test = buffer.cursor();
+        println!("Cursor after second 'TEST': {cursor_after_second_test:?}");
+        assert_eq!(cursor_after_second_test, LogicalPosition::new(0, 9));
+
+        // Check buffer content
+        let content = buffer.content().get_text();
+        println!("Buffer content: '{content}'");
+        assert_eq!(content, "TEST\tTEST");
+    }
 }

--- a/src/repl/views/terminal_renderer.rs
+++ b/src/repl/views/terminal_renderer.rs
@@ -131,7 +131,15 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
 
     /// Calculate visual length of text, excluding ANSI escape sequences
     /// Accounts for double-byte characters that take 2 terminal columns
+    /// For backward compatibility, uses default tab width of 0 (original behavior)
     fn visual_length(&self, text: &str) -> usize {
+        self.visual_length_with_tabs(text, 0)
+    }
+
+    /// Calculate visual length of text with proper tab expansion
+    /// Accounts for double-byte characters that take 2 terminal columns
+    /// Tabs expand to align to the next tab stop based on tab_width
+    fn visual_length_with_tabs(&self, text: &str, tab_width: usize) -> usize {
         let mut length = 0;
         let mut in_escape = false;
 
@@ -141,12 +149,25 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
             } else if in_escape && ch == 'm' {
                 in_escape = false;
             } else if !in_escape {
-                // Use unicode-width to get proper display width
-                // Most double-byte characters (CJK) have width 2
-                if let Some(w) = unicode_width::UnicodeWidthChar::width(ch) {
-                    length += w;
+                match ch {
+                    '\t' if tab_width > 0 => {
+                        // Calculate spaces to next tab stop
+                        let spaces_to_next_tab = tab_width - (length % tab_width);
+                        length += spaces_to_next_tab;
+                    }
+                    '\t' => {
+                        // Original behavior: tabs have zero width
+                        // This maintains backward compatibility
+                    }
+                    _ => {
+                        // Use unicode-width to get proper display width
+                        // Most double-byte characters (CJK) have width 2
+                        if let Some(w) = unicode_width::UnicodeWidthChar::width(ch) {
+                            length += w;
+                        }
+                        // Control characters and zero-width characters have no width
+                    }
                 }
-                // Control characters and zero-width characters have no width
             }
         }
 
@@ -209,23 +230,31 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
         };
         let available_width = (self.terminal_size.0 as usize).saturating_sub(used_width);
 
-        // Truncate text to fit within terminal width, accounting for double-byte characters
-        let display_text = if self.visual_length(line_info.text) > available_width {
-            let mut result = String::new();
-            let mut current_width = 0;
+        // Truncate text to fit within terminal width, accounting for double-byte characters and tabs
+        let tab_width = view_model.pane_manager().get_tab_width();
+        let display_text =
+            if self.visual_length_with_tabs(line_info.text, tab_width) > available_width {
+                let mut result = String::new();
+                let mut current_width = 0;
 
-            for ch in line_info.text.chars() {
-                let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-                if current_width + char_width > available_width {
-                    break;
+                for ch in line_info.text.chars() {
+                    let char_width = match ch {
+                        '\t' => {
+                            // Calculate spaces to next tab stop
+                            tab_width - (current_width % tab_width)
+                        }
+                        _ => UnicodeWidthChar::width(ch).unwrap_or(0),
+                    };
+                    if current_width + char_width > available_width {
+                        break;
+                    }
+                    result.push(ch);
+                    current_width += char_width;
                 }
-                result.push(ch);
-                current_width += char_width;
-            }
-            result
-        } else {
-            line_info.text.to_string()
-        };
+                result
+            } else {
+                line_info.text.to_string()
+            };
 
         // Render text with visual selection highlighting if applicable
         self.render_text_with_selection(
@@ -258,7 +287,7 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
     ) -> Result<()> {
         // Check if we're in visual mode and have a selection
         let mode = view_model.get_mode();
-        if mode == EditorMode::Visual {
+        if matches!(mode, EditorMode::Visual) {
             tracing::trace!("render_text_with_selection: Visual mode detected, pane={:?}, line_number={:?}, logical_line={}, text='{}'", pane, line_number, logical_line, text);
 
             // BUGFIX: Use logical_line directly instead of relying on line_number
@@ -267,10 +296,12 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
             // logical line number regardless of whether this is a continuation or not.
             let chars: Vec<char> = text.chars().collect();
             let selection_state = view_model.get_visual_selection();
+            let tab_width = view_model.pane_manager().get_tab_width();
 
             tracing::trace!(
-                "render_text_with_selection: selection_state={:?}",
-                selection_state
+                "render_text_with_selection: selection_state={:?}, tab_width={}",
+                selection_state,
+                tab_width
             );
 
             for (col_index, ch) in chars.iter().enumerate() {
@@ -285,23 +316,59 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
 
                 let is_selected = view_model.is_position_selected(position, pane);
 
-                if is_selected {
-                    tracing::debug!(
-                        "render_text_with_selection: highlighting character '{}' at {:?}",
-                        ch,
-                        position
-                    );
-                    // Apply visual selection styling: inverse + blue
-                    write!(
-                        self.render_stream,
-                        "{}{}{ch}{}",
-                        ansi::BG_SELECTED,
-                        ansi::FG_SELECTED,
-                        ansi::RESET
-                    )?
-                } else {
-                    // Normal character rendering
-                    write!(self.render_stream, "{ch}")?
+                match *ch {
+                    '\t' => {
+                        // Simple tab: always render tab_width spaces
+                        let spaces_to_next_tab = if tab_width > 0 {
+                            tab_width
+                        } else {
+                            0 // No expansion if tab width is 0
+                        };
+
+                        if is_selected {
+                            tracing::debug!(
+                                "render_text_with_selection: highlighting tab ({} spaces) at {:?}",
+                                spaces_to_next_tab,
+                                position
+                            );
+                            // Render highlighted spaces for the full tab expansion
+                            for _ in 0..spaces_to_next_tab {
+                                write!(
+                                    self.render_stream,
+                                    "{}{} {}",
+                                    ansi::BG_SELECTED,
+                                    ansi::FG_SELECTED,
+                                    ansi::RESET
+                                )?;
+                            }
+                        } else {
+                            // Render regular spaces for the full tab expansion
+                            for _ in 0..spaces_to_next_tab {
+                                write!(self.render_stream, " ")?;
+                            }
+                        }
+                    }
+                    _ => {
+                        // Regular character handling
+                        if is_selected {
+                            tracing::debug!(
+                                "render_text_with_selection: highlighting character '{}' at {:?}",
+                                ch,
+                                position
+                            );
+                            // Apply visual selection styling: inverse + blue
+                            write!(
+                                self.render_stream,
+                                "{}{}{ch}{}",
+                                ansi::BG_SELECTED,
+                                ansi::FG_SELECTED,
+                                ansi::RESET
+                            )?
+                        } else {
+                            // Normal character rendering
+                            write!(self.render_stream, "{ch}")?
+                        }
+                    }
                 }
             }
             return Ok(());
@@ -312,8 +379,21 @@ impl<RS: RenderStream> TerminalRenderer<RS> {
             );
         }
 
-        // No selection or not in visual mode - render normally
-        write!(self.render_stream, "{text}")?;
+        // No selection or not in visual mode - render normally, but expand tabs
+        let tab_width = view_model.pane_manager().get_tab_width();
+        for ch in text.chars() {
+            match ch {
+                '\t' => {
+                    // Expand tabs to spaces
+                    for _ in 0..tab_width {
+                        write!(self.render_stream, " ")?;
+                    }
+                }
+                _ => {
+                    write!(self.render_stream, "{ch}")?;
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1125,6 +1205,39 @@ mod tests {
 
             // Test empty string
             assert_eq!(renderer.visual_length(""), 0);
+        }
+    }
+
+    #[test]
+    fn visual_length_with_tabs_should_calculate_tab_stops_correctly() {
+        let render_stream = MockRenderStream::new();
+        if let Ok(renderer) = TerminalRenderer::with_render_stream(render_stream) {
+            // Test single tab with tab width 4
+            assert_eq!(renderer.visual_length_with_tabs("\t", 4), 4);
+
+            // Test text before tab - tab should align to next 4-column boundary
+            assert_eq!(renderer.visual_length_with_tabs("a\t", 4), 4); // "a" (1) + tab to column 4 = 4
+            assert_eq!(renderer.visual_length_with_tabs("ab\t", 4), 4); // "ab" (2) + tab to column 4 = 4
+            assert_eq!(renderer.visual_length_with_tabs("abc\t", 4), 4); // "abc" (3) + tab to column 4 = 4
+            assert_eq!(renderer.visual_length_with_tabs("abcd\t", 4), 8); // "abcd" (4) + tab to column 8 = 8
+
+            // Test multiple tabs
+            assert_eq!(renderer.visual_length_with_tabs("\t\t", 4), 8); // Two tabs = 8 spaces
+            assert_eq!(renderer.visual_length_with_tabs("a\tb\t", 4), 8); // "a" + tab + "b" + tab = 8
+
+            // Test tab width 8
+            assert_eq!(renderer.visual_length_with_tabs("\t", 8), 8);
+            assert_eq!(renderer.visual_length_with_tabs("a\t", 8), 8);
+            assert_eq!(renderer.visual_length_with_tabs("abcdefg\t", 8), 8); // 7 chars + 1 space to column 8
+            assert_eq!(renderer.visual_length_with_tabs("abcdefgh\t", 8), 16); // 8 chars + 8 spaces to column 16
+
+            // Test mixed content with tabs
+            assert_eq!(renderer.visual_length_with_tabs("hello\tworld", 4), 13); // "hello" (5) + 3 spaces + "world" (5) = 13
+
+            // Test backward compatibility - tab width 0 should give zero width tabs
+            assert_eq!(renderer.visual_length_with_tabs("\t", 0), 0);
+            assert_eq!(renderer.visual_length_with_tabs("hello\tworld", 0), 10);
+            // Just "hello" + "world"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implemented configurable tab character support with a simple 4-space system
- Fixed text rendering to properly expand tabs to spaces in all modes
- Fixed cursor positioning to correctly handle tab display width

## Changes
- Added `InsertTabCommand` to handle Tab key in Insert mode  
- Added configurable `tab_width` field to PaneManager (default 4)
- Modified `DisplayChar` to always use fixed tab width regardless of column position
- Fixed text rendering to expand tabs to spaces during normal rendering (not just in Visual mode)
- Added comprehensive tests for tab width handling and cursor positioning

## Test Plan
- [x] Tab key inserts tab character in Insert mode
- [x] Tab always advances cursor by 4 display columns
- [x] Text after tab appears at correct position
- [x] Visual selection properly highlights expanded tab spaces
- [x] All existing tests pass
- [x] Pre-commit checks pass

Fixes #151

🤖 Generated with [Claude Code](https://claude.ai/code)