### PR TITLE
Fix #152: Support tab stop configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blueline"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/repl/commands/events.rs
+++ b/src/repl/commands/events.rs
@@ -18,6 +18,8 @@ pub enum Setting {
     LineNumbers,
     /// System clipboard integration
     Clipboard,
+    /// Tab stop width
+    TabStop,
 }
 
 /// Values for settings
@@ -27,6 +29,8 @@ pub enum SettingValue {
     On,
     /// Disable the setting
     Off,
+    /// Numeric value for the setting
+    Number(usize),
 }
 
 /// Events that commands can produce to request changes

--- a/src/repl/commands/ex_commands.rs
+++ b/src/repl/commands/ex_commands.rs
@@ -135,6 +135,42 @@ impl ExCommand for ShowProfileCommand {
     }
 }
 
+/// Set tabstop command handler (for :set tabstop <number>)
+pub struct SetTabstopCommand;
+
+impl ExCommand for SetTabstopCommand {
+    fn can_handle(&self, command: &str) -> bool {
+        // Check if command starts with "set tabstop " followed by a number
+        if let Some(value_str) = command.strip_prefix("set tabstop ") {
+            value_str.parse::<usize>().is_ok()
+        } else {
+            false
+        }
+    }
+
+    fn execute(&self, command: &str, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        if let Some(value_str) = command.strip_prefix("set tabstop ") {
+            if let Ok(tab_width) = value_str.parse::<usize>() {
+                // Validate tab width (must be between 1 and 8)
+                let tab_width = tab_width.clamp(1, 8);
+                Ok(vec![CommandEvent::SettingChangeRequested {
+                    setting: Setting::TabStop,
+                    value: SettingValue::Number(tab_width),
+                }])
+            } else {
+                tracing::warn!("Invalid tabstop value: {}", value_str);
+                Ok(vec![])
+            }
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "SetTabstopCommand"
+    }
+}
+
 /// Type alias to reduce complexity for ex command collection
 type ExCommandCollection = Vec<Box<dyn ExCommand + Send>>;
 
@@ -181,6 +217,7 @@ impl ExCommandRegistry {
             Box::new(SetWrapCommand),
             Box::new(SetNumberCommand),
             Box::new(SetClipboardCommand),
+            Box::new(SetTabstopCommand),
             Box::new(ShowProfileCommand),
             Box::new(GoToLineCommand),
         ];
@@ -263,6 +300,43 @@ mod tests {
         assert!(cmd.can_handle("set wrap on"));
         assert!(cmd.can_handle("set wrap off"));
         assert!(!cmd.can_handle("set wrap"));
+    }
+
+    #[test]
+    fn set_tabstop_command_should_handle_tabstop_settings() {
+        let cmd = SetTabstopCommand;
+        assert!(cmd.can_handle("set tabstop 4"));
+        assert!(cmd.can_handle("set tabstop 8"));
+        assert!(cmd.can_handle("set tabstop 2"));
+        assert!(!cmd.can_handle("set tabstop"));
+        assert!(!cmd.can_handle("set tabstop abc"));
+    }
+
+    #[test]
+    fn set_tabstop_command_should_produce_setting_change_event() {
+        let cmd = SetTabstopCommand;
+        let context = create_test_context();
+
+        // Test valid tab width
+        let result = cmd.execute("set tabstop 4", &context).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            CommandEvent::SettingChangeRequested {
+                setting: Setting::TabStop,
+                value: SettingValue::Number(4),
+            }
+        );
+
+        // Test clamping to max value
+        let result = cmd.execute("set tabstop 20", &context).unwrap();
+        assert_eq!(
+            result[0],
+            CommandEvent::SettingChangeRequested {
+                setting: Setting::TabStop,
+                value: SettingValue::Number(8), // Should be clamped to 8
+            }
+        );
     }
 
     #[test]

--- a/src/repl/view_models/settings_manager.rs
+++ b/src/repl/view_models/settings_manager.rs
@@ -34,6 +34,16 @@ impl ViewModel {
                 self.set_clipboard_enabled(enable)?;
                 Ok(())
             }
+            Setting::TabStop => {
+                if let SettingValue::Number(width) = value {
+                    self.pane_manager.set_tab_width(width);
+                    let visibility_events = self.pane_manager.rebuild_display_caches_and_sync();
+                    let mut events = vec![ViewEvent::FullRedrawRequired];
+                    events.extend(visibility_events);
+                    let _ = self.emit_view_event(events);
+                }
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implemented `:set tabstop <number>` command to allow dynamic configuration of tab width
- Tab width can be set between 1 and 8 spaces (values outside range are clamped)
- Display is immediately refreshed when tab width changes

## Changes
- Added `SetTabstopCommand` to handle `:set tabstop <number>` syntax  
- Extended `Setting` enum with `TabStop` variant for tab width configuration
- Added `Number(usize)` variant to `SettingValue` enum for numeric settings
- Integrated with existing tab width infrastructure in PaneManager
- Added comprehensive tests for command parsing, event generation, and value clamping

## How it works
Users can now configure tab width during runtime:
- `:set tabstop 2` - sets tab width to 2 spaces
- `:set tabstop 4` - sets tab width to 4 spaces (default)
- `:set tabstop 8` - sets tab width to 8 spaces

All existing tabs in the buffer are immediately re-rendered with the new width.

## Test Plan
- [x] Command parses valid syntax (`:set tabstop 4`)
- [x] Command rejects invalid syntax (`:set tabstop abc`)
- [x] Tab width changes when command is executed
- [x] Display refreshes immediately after change
- [x] Values are clamped to 1-8 range
- [x] All unit tests pass
- [x] Pre-commit checks pass

Fixes #152

🤖 Generated with [Claude Code](https://claude.ai/code)