### PR TITLE
Fix Visual Line mode deletion to work with complete lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blueline"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueline"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Sam Wisely <samwisely75@gmail.com>"]
 description = "A lightweight, profile-based HTTP client with REPL interface"
 edition = "2021"

--- a/tests/common/world.rs
+++ b/tests/common/world.rs
@@ -35,11 +35,13 @@ use super::terminal_state::TerminalState;
 /// Application mode following Vim conventions
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AppMode {
-    Normal,  // No status message, cursor not in command line
-    Insert,  // "-- INSERT --" message (left-aligned, bold)
-    Visual,  // "-- VISUAL --" message (left-aligned, bold)
-    Command, // Cursor at bottom row with ":" at column 1
-    Unknown, // Fallback for unclear state
+    Normal,      // No status message, cursor not in command line
+    Insert,      // "-- INSERT --" message (left-aligned, bold)
+    Visual,      // "-- VISUAL --" message (left-aligned, bold)
+    VisualLine,  // "-- VISUAL LINE --" message (left-aligned, bold)
+    VisualBlock, // "-- VISUAL BLOCK --" message (left-aligned, bold)
+    Command,     // Cursor at bottom row with ":" at column 1
+    Unknown,     // Fallback for unclear state
 }
 
 /// The Cucumber World for Blueline integration tests
@@ -895,6 +897,16 @@ impl BluelineWorld {
             if last_line.contains("-- INSERT --") {
                 debug!("Detected Insert mode: found '-- INSERT --' in status bar");
                 return AppMode::Insert;
+            }
+
+            if last_line.contains("-- VISUAL LINE --") {
+                debug!("Detected Visual Line mode: found '-- VISUAL LINE --' in status bar");
+                return AppMode::VisualLine;
+            }
+
+            if last_line.contains("-- VISUAL BLOCK --") {
+                debug!("Detected Visual Block mode: found '-- VISUAL BLOCK --' in status bar");
+                return AppMode::VisualBlock;
             }
 
             if last_line.contains("-- VISUAL --") {

--- a/tests/steps/modes.rs
+++ b/tests/steps/modes.rs
@@ -104,6 +104,26 @@ async fn then_should_be_visual_mode(world: &mut BluelineWorld) {
     );
 }
 
+#[then(regex = r"^I (?:should be|am) in Visual Line mode$")]
+async fn then_should_be_visual_line_mode(world: &mut BluelineWorld) {
+    let current_mode = world.get_current_mode().await;
+    assert_eq!(
+        current_mode,
+        AppMode::VisualLine,
+        "Expected Visual Line mode, but found {current_mode:?}"
+    );
+}
+
+#[then(regex = r"^I (?:should be|am) in Visual Block mode$")]
+async fn then_should_be_visual_block_mode(world: &mut BluelineWorld) {
+    let current_mode = world.get_current_mode().await;
+    assert_eq!(
+        current_mode,
+        AppMode::VisualBlock,
+        "Expected Visual Block mode, but found {current_mode:?}"
+    );
+}
+
 #[then("I should remain in Insert mode")]
 async fn then_should_remain_insert_mode(world: &mut BluelineWorld) {
     debug!("Verifying still in Insert mode");

--- a/tests/steps/navigation.rs
+++ b/tests/steps/navigation.rs
@@ -38,6 +38,18 @@ async fn when_press_key(world: &mut BluelineWorld, key: String) {
                 .send_key_event(KeyCode::Char('v'), KeyModifiers::empty())
                 .await
         }
+        "V" => {
+            info!("Pressing 'V' key to enter visual line mode");
+            world
+                .send_key_event(KeyCode::Char('V'), KeyModifiers::empty())
+                .await
+        }
+        "Ctrl-v" => {
+            info!("Pressing Ctrl+V to enter visual block mode");
+            world
+                .send_key_event(KeyCode::Char('v'), KeyModifiers::CONTROL)
+                .await
+        }
         "$" => {
             info!("Pressing '$' key to move to end of line");
             world
@@ -106,6 +118,18 @@ async fn when_press_key(world: &mut BluelineWorld, key: String) {
             info!("Pressing 'd' key for delete command");
             world
                 .send_key_event(KeyCode::Char('d'), KeyModifiers::empty())
+                .await
+        }
+        "x" => {
+            info!("Pressing 'x' key for cut command");
+            world
+                .send_key_event(KeyCode::Char('x'), KeyModifiers::empty())
+                .await
+        }
+        "y" => {
+            info!("Pressing 'y' key for yank command");
+            world
+                .send_key_event(KeyCode::Char('y'), KeyModifiers::empty())
                 .await
         }
         "shift+Left" => {


### PR DESCRIPTION
## Summary
Fixes a critical bug in Visual Line mode where the 'd' command was incorrectly deleting partial content instead of complete lines as expected in vim.

## Problem
- When using Visual Line mode (`Shift+V`) and pressing 'd' to delete, the operation was deleting from cursor position to cursor position across lines
- This left partial content instead of deleting complete lines as expected in vim
- Example: Selecting lines 2-3 with cursor at column 5 would delete from column 5 of line 2 to column 5 of line 3, leaving fragments

## Solution
- Added dedicated `delete_visual_line_selection()` method for Visual Line mode
- Visual Line deletion now works from beginning of first selected line to end of last selected line (including newlines)
- Properly handles edge cases when deleting the last lines in buffer
- Cursor positioned at beginning of first deleted line after operation

## Changes
- **src/repl/view_models/pane_state/text_operations.rs**: Added Visual Line-specific deletion logic
- **tests/steps/navigation.rs**: Added support for "V", "Ctrl-v", "x", "y" keys in tests
- **tests/steps/modes.rs**: Added Visual Line and Visual Block mode assertions  
- **tests/common/world.rs**: Extended AppMode enum and detection for Visual Line/Block modes

## Testing
Visual Line mode now correctly:
- Deletes complete lines when pressing 'd'
- Maintains proper cursor positioning
- Handles single and multi-line selections
- Works with cut ('x') and yank ('y') operations

## Test Plan
1. Enter Visual Line mode with `Shift+V`
2. Select multiple lines with `j/k`
3. Press 'd' to delete
4. Verify complete lines are deleted, not partial content
5. Verify cursor is positioned at beginning of first deleted line

🤖 Generated with [Claude Code](https://claude.ai/code)