### PR TITLE
Fix #147: Implement block-wise paste for Visual Block mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blueline"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/repl/view_models/cursor_manager.rs
+++ b/src/repl/view_models/cursor_manager.rs
@@ -127,5 +127,27 @@ impl ViewModel {
         self.emit_view_event(events)
     }
 
+    /// Get display line count for the current pane
+    pub fn get_display_line_count(&self) -> usize {
+        if let Some(pane_state) = self.pane_manager.get_current_pane_state() {
+            pane_state.display_cache.display_line_count()
+        } else {
+            0
+        }
+    }
+
+    /// Get display line length for a specific line index in the current pane
+    pub fn get_display_line_length(&self, line_index: usize) -> usize {
+        if let Some(pane_state) = self.pane_manager.get_current_pane_state() {
+            if let Some(display_line) = pane_state.display_cache.get_display_line(line_index) {
+                display_line.display_width()
+            } else {
+                0
+            }
+        } else {
+            0
+        }
+    }
+
     // Scrolling methods are implemented elsewhere - avoiding duplication
 }

--- a/src/repl/view_models/mod.rs
+++ b/src/repl/view_models/mod.rs
@@ -24,3 +24,4 @@ pub use core::ViewModel;
 pub use core::DisplayLineData;
 pub use pane_manager::PaneManager;
 pub use pane_state::PaneState;
+pub use yank_buffer::{YankEntry, YankType};

--- a/src/repl/view_models/pane_manager.rs
+++ b/src/repl/view_models/pane_manager.rs
@@ -263,6 +263,15 @@ impl PaneManager {
         }
     }
 
+    /// Insert text block-wise at specific positions (for block paste operations)
+    pub fn insert_block_wise(
+        &mut self,
+        start_position: LogicalPosition,
+        block_lines: &[&str],
+    ) -> Vec<ViewEvent> {
+        self.panes[self.current_pane].insert_block_wise(start_position, block_lines)
+    }
+
     /// Get the length of the current line in the current pane
     pub fn get_current_line_length(&self) -> usize {
         let current_pane = &self.panes[self.current_pane];


### PR DESCRIPTION
## Summary
- Implements proper rectangular paste behavior for Visual Block mode
- Adds yank type tracking (Character, Line, Block) to preserve selection semantics
- Fixes clipboard synchronization to maintain yank type metadata

## Changes
- **Added YankType enum** to track whether yanked text is character-wise, line-wise, or block-wise
- **Implemented insert_block_wise()** method for proper rectangular text insertion
- **Fixed cut/yank handlers** to preserve visual mode type when yanking
- **Fixed clipboard sync** to only overwrite metadata when clipboard content changes externally
- **Added display cache rebuild** to ensure immediate visual feedback after paste

## Test Plan
- [x] Select block in Visual Block mode (Ctrl+V) and cut with 'x'
- [x] Paste with 'P' at cursor position - should insert block rectangularly
- [x] Paste with 'p' after cursor - should insert block one column to the right
- [x] Verify immediate visual feedback without needing to move cursor
- [x] Test with blocks of different sizes and at various buffer positions
- [x] All existing tests pass

This completes the block-wise paste feature from Phase 7 of visual mode implementation (#147), providing users with proper multi-cursor-like editing capabilities in Visual Block mode.

🤖 Generated with [Claude Code](https://claude.ai/code)