### PR TITLE
Complete Visual Mode features: 'gv' command and flickering fix

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -1,5 +1,70 @@
 # Session Notes
 
+## 2025-08-17 Session - Complete Visual Mode Features (Issue #147)
+
+### User Request Summary
+- User returned and asked to check open issues
+- Identified Issue #147 was closed but 'gv' command and Unicode support were not implemented
+- Implementing missing features from Phase 7 of visual mode implementation
+
+### What We Accomplished
+
+✅ **Implemented 'gv' Command (Visual Selection Repeat)**
+- **Branch**: `feature/complete-visual-mode-features`
+- **Implementation**: Added full support for 'gv' command to restore last visual selection
+- **Key Components**:
+  - Added `RepeatVisualSelectionCommand` that responds to 'v' in GPrefix mode
+  - Added tracking of last visual selection (start, end, mode) in PaneState
+  - Saving selection state when exiting any visual mode
+  - Restoring selection with proper cursor positioning on 'gv'
+- **Architecture Changes**:
+  - Added `last_visual_selection_start/end` and `last_visual_mode` fields to PaneState
+  - Created `VisualSelectionRestoreResult` type alias to avoid clippy complexity warnings
+  - Proper event flow: Command → Controller → ViewModel → PaneManager → PaneState
+- **Bug Fix**: Fixed issue where visual selections were not saved when cut/delete operations cleared them
+  - Added `save_last_visual_selection_before_clear()` helper method
+  - Now saves selection before clearing in delete operations (x, d commands)
+- **Quality**: All 377 unit tests passing, pre-commit checks pass
+
+### Technical Implementation Details
+
+1. **Command Layer**: 
+   - `RepeatVisualSelectionCommand` in `src/repl/commands/mode.rs`
+   - Registered in command registry with proper priority
+
+2. **Event System**:
+   - Added `RepeatVisualSelectionRequested` to `CommandEvent` enum
+   - Proper event handling in `AppController::handle_repeat_visual_selection()`
+
+3. **State Management**:
+   - PaneState tracks last selection in three new fields
+   - Selection saved automatically on visual mode exit
+   - Restoration includes mode type and cursor position
+
+4. **Type Safety**:
+   - Used type alias to satisfy clippy type complexity requirements
+   - Clean separation of concerns across layers
+
+### What's Still Pending from Issue #147
+
+❌ **Unicode/Multi-byte Character Support**
+- Visual Block selection still uses raw column indices
+- No special handling for double-width characters
+- Would require display width calculations in selection logic
+
+❌ **Comprehensive Testing**
+- No integration tests for 'gv' command yet
+- No Unicode character tests for visual modes
+
+❌ **Documentation**
+- COMMANDS.md not created/updated
+- Visual mode documentation not present
+
+### Next Steps
+- Unicode support would require significant changes to use display widths
+- Integration tests should be added for 'gv' command
+- Consider creating COMMANDS.md documentation
+
 ## 2025-08-15 Session - Visual Block Commands Implementation 🔄 IN PROGRESS
 
 ### Previous Context - Issue #161 Phases 1-4: PaneState Business Logic Migration ✅ COMPLETE

--- a/src/repl/commands/events.rs
+++ b/src/repl/commands/events.rs
@@ -128,6 +128,9 @@ pub enum CommandEvent {
     /// Request to exit Visual Block Insert mode with text replication
     ExitVisualBlockInsertRequested,
 
+    /// Request to repeat the last visual selection (gv command)
+    RepeatVisualSelectionRequested,
+
     /// No action needed (for commands that only query state)
     NoAction,
 }
@@ -263,6 +266,11 @@ impl CommandEvent {
     /// Create an exit visual block insert event
     pub fn exit_visual_block_insert() -> Self {
         Self::ExitVisualBlockInsertRequested
+    }
+
+    /// Create a repeat visual selection event
+    pub fn repeat_visual_selection() -> Self {
+        Self::RepeatVisualSelectionRequested
     }
 }
 

--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -72,7 +72,7 @@ pub use mode::{
     EnterInsertModeCommand, EnterVisualBlockModeCommand, EnterVisualLineModeCommand,
     EnterVisualModeCommand, ExCommandModeCommand, ExitInsertModeCommand,
     ExitVisualBlockInsertModeCommand, ExitVisualModeCommand, InsertAtBeginningOfLineCommand,
-    VisualBlockAppendCommand, VisualBlockInsertCommand,
+    RepeatVisualSelectionCommand, VisualBlockAppendCommand, VisualBlockInsertCommand,
 };
 pub use navigation::{
     BeginningOfLineCommand, EndKeyCommand, EndOfLineCommand, EndOfWordCommand, EnterGPrefixCommand,
@@ -107,6 +107,7 @@ impl CommandRegistry {
             // G mode commands (high priority - must be processed before regular g handling)
             Box::new(GoToTopCommand),
             Box::new(GoToBottomCommand),
+            Box::new(RepeatVisualSelectionCommand), // gv command
             Box::new(EnterGPrefixCommand),
             // Scroll commands (higher priority than regular movement)
             Box::new(ScrollLeftCommand),

--- a/src/repl/commands/mode.rs
+++ b/src/repl/commands/mode.rs
@@ -184,6 +184,28 @@ impl Command for EnterVisualBlockModeCommand {
     }
 }
 
+/// Repeat last visual selection (gv command)
+pub struct RepeatVisualSelectionCommand;
+
+impl Command for RepeatVisualSelectionCommand {
+    fn is_relevant(&self, context: &CommandContext, event: &KeyEvent) -> bool {
+        // This command is triggered by 'v' when in GPrefix mode (after pressing 'g')
+        matches!(event.code, KeyCode::Char('v'))
+            && context.state.current_mode == EditorMode::GPrefix
+            && event.modifiers.is_empty()
+    }
+
+    fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+        tracing::debug!("RepeatVisualSelectionCommand executing - restoring last visual selection");
+        // This will trigger the restoration of the last visual selection
+        Ok(vec![CommandEvent::repeat_visual_selection()])
+    }
+
+    fn name(&self) -> &'static str {
+        "RepeatVisualSelection"
+    }
+}
+
 /// Enter command mode (: key)
 pub struct EnterCommandModeCommand;
 

--- a/src/repl/view_models/core.rs
+++ b/src/repl/view_models/core.rs
@@ -384,6 +384,20 @@ impl ViewModel {
     pub fn pane_manager(&self) -> &PaneManager {
         &self.pane_manager
     }
+
+    /// Restore the last visual selection (for 'gv' command)
+    /// Returns the mode to enter if restoration successful
+    pub fn restore_last_visual_selection(&mut self) -> anyhow::Result<Option<EditorMode>> {
+        // Delegate to the pane manager to restore selection in current pane
+        match self.pane_manager.restore_last_visual_selection() {
+            Some((mode, events)) => {
+                // Emit the view events
+                self.emit_view_event(events)?;
+                Ok(Some(mode))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 impl Default for ViewModel {

--- a/src/repl/view_models/mode_manager.rs
+++ b/src/repl/view_models/mode_manager.rs
@@ -119,7 +119,10 @@ impl ViewModel {
 
         if entering_visual_mode && !exiting_visual_mode {
             // Entering any visual mode from non-visual mode
-            events.extend(self.pane_manager.start_visual_selection());
+            // Only start a new selection if one doesn't already exist (e.g., not restoring via 'gv')
+            if !self.pane_manager.has_visual_selection() {
+                events.extend(self.pane_manager.start_visual_selection());
+            }
         } else if exiting_visual_mode && !entering_visual_mode {
             // Exiting visual mode to non-visual mode
             events.extend(self.pane_manager.end_visual_selection());

--- a/src/repl/view_models/pane_manager.rs
+++ b/src/repl/view_models/pane_manager.rs
@@ -34,7 +34,7 @@
 
 use crate::repl::events::{EditorMode, LogicalPosition, Pane, PaneCapabilities, ViewEvent};
 use crate::repl::geometry::Position;
-use crate::repl::view_models::pane_state::PaneState;
+use crate::repl::view_models::pane_state::{PaneState, VisualSelectionRestoreResult};
 
 /// Type alias for visual selection state to reduce complexity
 type VisualSelectionState = (
@@ -206,6 +206,12 @@ impl PaneManager {
         self.panes[pane].is_position_selected(position)
     }
 
+    /// Check if current pane has an active visual selection
+    pub fn has_visual_selection(&self) -> bool {
+        let (start, _end) = self.panes[self.current_pane].get_visual_selection();
+        start.is_some()
+    }
+
     /// Start visual selection in current area
     pub fn start_visual_selection(&mut self) -> Vec<ViewEvent> {
         // Delegate to current pane
@@ -236,6 +242,12 @@ impl PaneManager {
         new_position: LogicalPosition,
     ) -> Option<ViewEvent> {
         self.panes[self.current_pane].update_visual_selection_on_cursor_move(new_position)
+    }
+
+    /// Restore the last visual selection (for 'gv' command)
+    /// Returns the mode and view events if restoration successful
+    pub fn restore_last_visual_selection(&mut self) -> VisualSelectionRestoreResult {
+        self.panes[self.current_pane].restore_last_visual_selection()
     }
 
     /// Delete selected text from the current pane

--- a/src/repl/view_models/pane_state/mod.rs
+++ b/src/repl/view_models/pane_state/mod.rs
@@ -38,6 +38,7 @@ pub mod visual_selection;
 pub mod word_navigation;
 
 // Re-export key types for external use
+pub use visual_selection::VisualSelectionRestoreResult;
 
 /// Minimum width for line number column as specified in requirements
 const MIN_LINE_NUMBER_WIDTH: usize = 3;
@@ -99,11 +100,15 @@ pub struct PaneState {
     pub scroll_offset: Position,  // (vertical, horizontal)
     pub visual_selection_start: Option<LogicalPosition>,
     pub visual_selection_end: Option<LogicalPosition>,
-    pub pane_dimensions: Dimensions,    // (width, height)
-    pub editor_mode: EditorMode,        // Current editor mode for this pane
-    pub line_number_width: usize,       // Width needed for line numbers display
-    pub virtual_column: usize,          // Vim-style virtual column - desired cursor position
-    pub capabilities: PaneCapabilities, // What operations are allowed on this pane
+    // Last visual selection for 'gv' command
+    pub last_visual_selection_start: Option<LogicalPosition>,
+    pub last_visual_selection_end: Option<LogicalPosition>,
+    pub last_visual_mode: Option<EditorMode>, // Track which visual mode was used
+    pub pane_dimensions: Dimensions,          // (width, height)
+    pub editor_mode: EditorMode,              // Current editor mode for this pane
+    pub line_number_width: usize,             // Width needed for line numbers display
+    pub virtual_column: usize,                // Vim-style virtual column - desired cursor position
+    pub capabilities: PaneCapabilities,       // What operations are allowed on this pane
 }
 
 impl PaneState {
@@ -121,6 +126,9 @@ impl PaneState {
             scroll_offset: Position::origin(),
             visual_selection_start: None,
             visual_selection_end: None,
+            last_visual_selection_start: None,
+            last_visual_selection_end: None,
+            last_visual_mode: None,
             pane_dimensions: Dimensions::new(pane_width, pane_height),
             editor_mode: EditorMode::Normal, // Start in Normal mode
             line_number_width: MIN_LINE_NUMBER_WIDTH, // Start with minimum width


### PR DESCRIPTION
## Summary
- Implemented 'gv' command (restore last visual selection) from Issue #147
- Fixed flickering issue that occurred on first Insert mode switch
- Updated SESSION_NOTES with implementation details

## Changes

### 'gv' Command Implementation
- Added `RepeatVisualSelectionCommand` that responds to 'v' in GPrefix mode
- Added tracking of last visual selection (start, end, mode) in PaneState
- Fixed bug where visual selections weren't saved when cut/delete operations cleared them
- Fixed issue where restored selection was immediately overwritten by new selection

### Flickering Fix
- Root cause: Cursor was initially hidden during terminal initialization
- First mode switch required changing both cursor style AND visibility state
- Solution: Modified initialization to not hide cursor initially, letting render_cursor() handle visibility consistently
- Now mode changes only update cursor style, not visibility state

## Test Plan
- [x] All 378 unit tests passing
- [x] Pre-commit checks pass (formatting, clippy, tests)
- [x] 'gv' command restores visual selection correctly
- [x] No flickering on first Insert mode switch
- [x] Subsequent mode switches continue to work smoothly

🤖 Generated with [Claude Code](https://claude.ai/code)