### PR TITLE
Migrate handle_paste_at_cursor to PasteAtCursorCommand

### DIFF
--- a/src/repl/unified_commands/mod.rs
+++ b/src/repl/unified_commands/mod.rs
@@ -19,6 +19,7 @@ pub mod delete_selection;
 pub mod exit_visual_block_insert;
 pub mod http;
 pub mod paste; // Added missing paste module
+pub mod paste_at_cursor;
 pub mod repeat_visual_selection;
 pub mod setting_change;
 pub mod show_profile;

--- a/src/repl/unified_commands/paste_at_cursor.rs
+++ b/src/repl/unified_commands/paste_at_cursor.rs
@@ -1,0 +1,208 @@
+//! # Paste At Cursor Command
+//!
+//! Command to paste yanked text at the current cursor position.
+//! This command migrates the functionality from handle_paste_at_cursor
+//! in the app_view_model to the unified command architecture.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::register_command;
+use crate::repl::models::events::view_events::ViewEvent;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+
+/// Command to paste yanked text at current cursor position
+///
+/// This command:
+/// 1. Handles Ctrl+V key combination in Normal mode
+/// 2. Gets yanked text from YankService
+/// 3. Uses paste_with_type() to paste at cursor position with type awareness
+/// 4. Updates status messages and logs the operation
+/// 5. Only works in writable panes
+#[derive(Default)]
+pub struct PasteAtCursorCommand;
+
+impl PasteAtCursorCommand {
+    /// Create new PasteAtCursorCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Command for PasteAtCursorCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        mode: EditorMode,
+        context: &CommandContext,
+    ) -> bool {
+        // Ctrl+V key in Normal mode (standard paste shortcut)
+        matches!(key_event.code, KeyCode::Char('v'))
+            && key_event.modifiers == KeyModifiers::CONTROL
+            && mode == EditorMode::Normal
+            && !context.is_read_only
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<ViewEvent>> {
+        // Get from YankService
+        if let Some(yank_entry) = context.services.yank.paste() {
+            tracing::debug!(
+                "Retrieved yank entry with type: {:?}, text length: {}",
+                yank_entry.yank_type,
+                yank_entry.text.len()
+            );
+
+            // Paste the text at current position (before cursor) using type-aware paste
+            context.app_state.paste_with_type(&yank_entry)?;
+
+            let char_count = yank_entry.text.chars().count();
+            let line_count = yank_entry.text.lines().count();
+
+            // Clear any previous status message (e.g., "1 line yanked")
+            context.app_state.clear_status_message();
+
+            tracing::info!(
+                "Pasted {} characters ({} lines) at cursor as {:?}",
+                char_count,
+                line_count,
+                yank_entry.yank_type
+            );
+        } else {
+            context
+                .app_state
+                .set_status_message("Nothing to paste".to_string());
+            tracing::warn!("No text in yank buffer to paste");
+        }
+
+        // Return UI update events
+        Ok(vec![
+            ViewEvent::CurrentAreaRedrawRequired,
+            ViewEvent::StatusBarUpdateRequired,
+        ])
+    }
+
+    fn name(&self) -> &'static str {
+        "PasteAtCursorCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+
+    #[test]
+    fn paste_at_cursor_command_should_return_correct_name() {
+        let command = PasteAtCursorCommand::new();
+        assert_eq!(command.name(), "PasteAtCursorCommand");
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_be_relevant_for_ctrl_v_in_normal_mode() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+        };
+
+        let ctrl_v_key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(command.is_relevant(ctrl_v_key, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_not_be_relevant_without_ctrl_modifier() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+        };
+
+        // Plain 'v' key should not be relevant
+        let v_key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE);
+        assert!(!command.is_relevant(v_key, EditorMode::Normal, &context));
+
+        // Shift+v should not be relevant
+        let shift_v_key = KeyEvent::new(KeyCode::Char('V'), KeyModifiers::SHIFT);
+        assert!(!command.is_relevant(shift_v_key, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_not_be_relevant_in_insert_mode() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Insert,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+        };
+
+        let ctrl_v_key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(!command.is_relevant(ctrl_v_key, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_not_be_relevant_in_visual_modes() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Visual,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+        };
+
+        let ctrl_v_key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(!command.is_relevant(ctrl_v_key, EditorMode::Visual, &context));
+        assert!(!command.is_relevant(ctrl_v_key, EditorMode::VisualLine, &context));
+        assert!(!command.is_relevant(ctrl_v_key, EditorMode::VisualBlock, &context));
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_not_be_relevant_in_read_only_pane() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Response,
+            is_read_only: true,
+            has_selection: false,
+        };
+
+        let ctrl_v_key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(!command.is_relevant(ctrl_v_key, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn paste_at_cursor_command_should_not_be_relevant_for_other_keys() {
+        let command = PasteAtCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+        };
+
+        // Test other Ctrl combinations
+        let ctrl_c_key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(!command.is_relevant(ctrl_c_key, EditorMode::Normal, &context));
+
+        let ctrl_x_key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert!(!command.is_relevant(ctrl_x_key, EditorMode::Normal, &context));
+
+        // Test other keys
+        let enter_key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(!command.is_relevant(enter_key, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = PasteAtCursorCommand;
+        assert_eq!(command.name(), "PasteAtCursorCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(PasteAtCursorCommand, "PasteAtCursorCommand");


### PR DESCRIPTION
## Summary
- Migrated handle_paste_at_cursor functionality from app_view_model to unified command system
- Created PasteAtCursorCommand that responds to Ctrl+V key combination in Normal mode
- Uses paste_with_type() for type-aware pasting at cursor position with comprehensive error handling

## Test plan
- [x] Unit tests for key relevance detection (Ctrl+V in Normal mode only)
- [x] Unit tests for mode restrictions (not in Insert, Visual, or read-only panes)
- [x] Unit tests for key combination validation (rejects plain 'v' or other modifiers)
- [x] Command auto-registers via inventory system for dynamic discovery
- [x] Integration with existing YankService and ViewEvent system

🤖 Generated with [Claude Code](https://claude.ai/code)