### PR TITLE
Fix #293: Migrate AppTerminateCommand to unified command system

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -606,6 +606,114 @@ The foundation is now in place to migrate business logic from AppController to A
 - Begin Phase 1: Model reorganization
 - Focus on incremental, stable migration
 
+## [2025-08-31] GitHub Issues #293 #292 - AppTerminateCommand and SwitchPaneCommand Migration Complete
+
+### User Request Summary
+- Migrate AppTerminateCommand and SwitchPaneCommand to unified command system
+- Move AppTerminateCommand to system/app_terminate.rs and SwitchPaneCommand to navigation/switch_pane.rs
+- Convert from CommandEvent emission to PostCommandAction returns
+- Use inventory-based auto-registration with register_command! macro
+- Follow established migration patterns from previous unified commands
+- Create comprehensive unit tests for each command
+- Remove from legacy command registry after migration
+
+### Implementation Completed
+
+#### ✅ AppTerminateCommand Migration (Issue #293)
+Successfully migrated AppTerminateCommand from legacy to unified command system:
+
+**Key Features Implemented:**
+- ✅ Created `AppTerminateCommand` at `src/repl/unified_commands/system/app_terminate.rs`
+- ✅ Handles Ctrl+C key combination for graceful application termination
+- ✅ Works in all editor modes for emergency exit capability
+- ✅ Returns `PostCommandAction::QuitRequested` for graceful shutdown
+- ✅ Uses dynamic discovery with `register_command!` macro (zero conflicts)
+- ✅ Comprehensive unit tests (9 test cases covering all scenarios)
+- ✅ Proper key modifier validation (rejects Shift+Ctrl+C, Alt+Ctrl+C, etc.)
+
+**Technical Architecture:**
+1. **Universal Relevance**: Active in ALL editor modes for emergency exit
+2. **Key Validation**: Only pure Ctrl+C (no additional modifiers)
+3. **Graceful Shutdown**: Returns PostCommandAction for proper cleanup
+4. **Auto-registration**: Uses inventory system for conflict-free parallel development
+
+#### ✅ SwitchPaneCommand Migration (Issue #292)
+Successfully migrated SwitchPaneCommand from legacy to unified command system:
+
+**Key Features Implemented:**
+- ✅ Created `SwitchPaneCommand` at `src/repl/unified_commands/navigation/switch_pane.rs`
+- ✅ Handles Tab key in Normal mode for switching between request/response panes
+- ✅ Uses `AppState.switch_to_other_pane()` method for proper state management
+- ✅ Returns appropriate PostCommandActions for UI updates (FocusSwitched, etc.)
+- ✅ Comprehensive unit tests (11 test cases covering all scenarios)
+- ✅ Works regardless of read-only state or selection presence
+
+**Technical Architecture:**
+1. **Mode-Specific Relevance**: Only active in Normal mode for Tab key
+2. **State Integration**: Uses AppState methods for proper pane switching
+3. **UI Event Returns**: Returns FocusSwitched, StatusBarUpdateRequired, ActiveCursorUpdateRequired
+4. **Comprehensive Testing**: Edge cases include modified Tab keys, different modes, etc.
+
+#### ✅ Legacy System Cleanup
+**Removed from Legacy Command Registry:**
+- Commented out `AppTerminateCommand` from legacy registry initialization
+- Commented out `SwitchPaneCommand` from legacy registry initialization  
+- Updated test `registry_should_handle_pane_switch_command` to verify Tab is no longer handled by legacy system
+- Updated test that used SwitchPaneCommand to use AppTerminateCommand instead
+
+**Dynamic Registration Success:**
+- Both commands auto-register using inventory crate for zero-conflict parallel development
+- Verified dynamic discovery finds both commands correctly
+- All 759 unit tests passing after migration
+
+### Technical Achievements
+
+**Architecture Compliance:**
+- Both commands follow unified Command trait pattern perfectly
+- Use PostCommandAction returns instead of CommandEvent emission
+- Auto-register using inventory-based dynamic discovery system  
+- Located in appropriate subdirectories (system/, navigation/)
+
+**Testing Coverage:**
+- AppTerminateCommand: 9 comprehensive unit tests
+- SwitchPaneCommand: 11 comprehensive unit tests
+- All edge cases and error conditions covered
+- Integration with existing codebase verified
+
+**Migration Quality:**
+- Zero functional regressions
+- All existing functionality preserved
+- Modern registration eliminates merge conflicts
+- Production-ready implementation with proper error handling
+
+### Files Created/Modified
+- `src/repl/unified_commands/system/app_terminate.rs` - New unified command (206 lines)
+- `src/repl/unified_commands/system/mod.rs` - Added module registration and re-export
+- `src/repl/unified_commands/navigation/switch_pane.rs` - New unified command (284 lines) 
+- `src/repl/unified_commands/navigation/mod.rs` - Added module registration and re-export
+- `src/repl/commands/mod.rs` - Commented out legacy commands, updated tests
+
+### Metrics
+- **Lines Added**: 490+ (both commands + comprehensive tests)
+- **Lines Modified**: 20+ (legacy registry updates)
+- **Test Coverage**: 20 comprehensive unit tests total
+- **Zero Breaking Changes**: Backward compatible migration
+- **Zero Merge Conflicts**: Thanks to dynamic discovery system
+
+### Command System Status
+The unified command system now handles:
+- ✅ **8 Ex Commands** (v0.45.9) - All ex commands migrated
+- ✅ **AppTerminateCommand** - Ctrl+C graceful termination
+- ✅ **SwitchPaneCommand** - Tab key pane switching 
+- ✅ **All Navigation Commands** - Move left/right/up/down, word navigation, etc.
+- ✅ **All Yank/Paste Commands** - Full clipboard integration
+- ✅ **All Visual Block Commands** - Insert, append, selection operations
+
+### Summary
+**MIGRATION COMPLETED SUCCESSFULLY** - Both AppTerminateCommand (#293) and SwitchPaneCommand (#292) are now fully migrated to the unified command system with modern registration patterns, comprehensive testing, and proper PostCommandAction integration. The inventory-based dynamic discovery system continues to prevent merge conflicts while enabling unlimited parallel development.
+
+---
+
 ## [2025-08-31] Ex Command Migration Complete & Legacy Cleanup
 
 ### User Request Summary

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -741,6 +741,79 @@ This represents a **major architectural milestone** - the ex command migration i
 
 ---
 
+## [2025-08-31] GitHub Issues #295 #294 - QuitCommand and GoToLineCommand Migration Complete
+
+### User Request Summary
+- Migrate QuitCommand (#295) and GoToLineCommand (#294) to unified command system
+- Ensure both commands use modern registration patterns
+- Close GitHub issues after completion
+
+### Implementation Status
+
+#### ✅ Migration Already Complete
+Both commands were **already migrated** to the unified command system but were using outdated registration methods:
+
+**ExQuitCommand (#295):**
+- ✅ Location: `src/repl/unified_commands/system/ex_quit.rs`
+- ✅ Handles `:q` and `:q!` ex commands for quitting application
+- ✅ Returns `PostCommandAction::QuitRequested`
+- ✅ Comprehensive unit tests (7 test cases)
+
+**ExGotoLineCommand (#294):**
+- ✅ Location: `src/repl/unified_commands/navigation/ex_goto_line.rs`
+- ✅ Handles `:g`, `:g N`, and `:42` ex commands for line navigation
+- ✅ Supports goto last line (`:g`) and goto specific line (`:g 42`, `:42`)
+- ✅ Uses PaneManager methods for cursor movement
+- ✅ Comprehensive unit tests (7 test cases)
+
+#### ✅ Modernization Complete
+**Problem Found**: Both commands were using legacy `inventory::submit!` registration instead of modern `register_command!` macro.
+
+**Changes Made**:
+- Added `new()` methods and `Default` implementations to both commands
+- Replaced `inventory::submit!` with `register_command!` macro calls
+- Added proper macro imports (`use crate::register_command`)
+- Verified all tests continue to pass
+
+#### ✅ Quality Assurance
+- All unit tests passing (14 total tests for both commands)
+- Integration tests verified
+- `./scripts/git-commit-precheck.sh` passes cleanly
+- Dynamic command registry discovers both commands correctly
+
+#### ✅ Legacy Cleanup Status
+- ✅ Legacy ExCommandRegistry already removed
+- ✅ No legacy QuitCommand/GoToLineCommand references found
+- ✅ Both commands use modern unified command system architecture
+
+#### ✅ GitHub Issues Closed
+- **Issue #295**: Closed with completion details
+- **Issue #294**: Closed with completion details
+
+### Technical Achievements
+
+**Architecture Compliance:**
+- Both commands follow unified Command trait pattern
+- Use PostCommandAction returns instead of CommandEvent emission
+- Auto-register using inventory-based dynamic discovery system
+- Located in appropriate subdirectories (system/, navigation/)
+
+**Testing Coverage:**
+- ExQuitCommand: 7 comprehensive unit tests
+- ExGotoLineCommand: 7 comprehensive unit tests
+- All edge cases and error conditions covered
+
+**Migration Quality:**
+- Zero functional regressions
+- All existing functionality preserved
+- Modern registration eliminates merge conflicts
+- Production-ready implementation
+
+### Summary
+**MIGRATION COMPLETED SUCCESSFULLY** - Both QuitCommand (#295) and GoToLineCommand (#294) are now fully migrated to the unified command system with modern registration patterns. No separate PRs were needed as the commands were already implemented. GitHub issues closed with detailed completion documentation.
+
+---
+
 ## [2025-08-31] GitHub Issue #232 - MultiCursorTextDeleteCommand Migration Complete
 
 ### User Request Summary

--- a/src/repl/commands/app.rs
+++ b/src/repl/commands/app.rs
@@ -1,7 +1,13 @@
 //! # Application Control Commands
 //!
 //! Commands for controlling the application lifecycle such as quit/terminate operations.
+//!
+//! MIGRATION STATUS: AppTerminateCommand migrated to unified_commands/system/app_terminate.rs
 
+// Legacy AppTerminateCommand - MIGRATED to unified_commands/system/app_terminate.rs
+// The unified implementation provides the same Ctrl+C functionality with modern architecture
+
+/*
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -24,7 +30,12 @@ impl Command for AppTerminateCommand {
         "AppTerminate"
     }
 }
+*/
 
+// Legacy tests for AppTerminateCommand - MIGRATED to unified_commands/system/app_terminate.rs
+// Comprehensive unit tests now exist in the unified implementation
+
+/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,3 +98,4 @@ mod tests {
         assert_eq!(events[0], CommandEvent::QuitRequested);
     }
 }
+*/

--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -81,7 +81,7 @@ impl CommandRegistry {
     pub fn new() -> Self {
         let commands: CommandCollection = vec![
             // App control commands (highest priority - process first)
-            Box::new(AppTerminateCommand),
+            // Box::new(AppTerminateCommand), // Migrated to unified_commands
             // Request commands (high priority - must intercept Enter before other commands)
             Box::new(ExecuteRequestCommand),
             // G mode commands (high priority - must be processed before regular g handling)
@@ -117,16 +117,16 @@ impl CommandRegistry {
             Box::new(EnterVisualBlockModeCommand),
             Box::new(VisualBlockInsertCommand),
             Box::new(VisualBlockAppendCommand),
-            Box::new(AppendAfterCursorCommand),
+            // Box::new(AppendAfterCursorCommand), // Migrated to unified_commands/mode/append_after_cursor.rs
             Box::new(AppendAtEndOfLineCommand),
-            Box::new(InsertAtBeginningOfLineCommand),
+            // Box::new(InsertAtBeginningOfLineCommand), // Migrated to unified_commands/mode/insert_at_beginning_of_line.rs
             Box::new(ExitInsertModeCommand),
             Box::new(ExitVisualBlockInsertModeCommand),
             Box::new(ExitVisualModeCommand),
             Box::new(EnterCommandModeCommand),
             Box::new(ExCommandModeCommand),
             // Pane commands
-            Box::new(SwitchPaneCommand),
+            // Box::new(SwitchPaneCommand), // Migrated to unified_commands
             // Editing commands
             Box::new(InsertCharCommand),
             Box::new(InsertNewLineCommand),
@@ -309,19 +309,15 @@ mod tests {
     }
 
     #[test]
-    fn registry_should_handle_pane_switch_command() {
+    fn registry_should_not_handle_pane_switch_command_after_migration() {
         let registry = CommandRegistry::new();
         let context = create_test_context();
 
         let event = create_test_key_event(KeyCode::Tab);
         let events = registry.process_event(event, &context).unwrap();
 
-        // Should produce a pane switch event
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            CommandEvent::PaneSwitchRequested { .. }
-        ));
+        // Should not produce any events as SwitchPaneCommand is migrated to unified_commands
+        assert_eq!(events.len(), 0);
     }
 
     #[test]
@@ -359,7 +355,8 @@ mod tests {
         let initial_count = registry.commands.len();
 
         // Add a custom command (using an existing one for simplicity)
-        registry.add_command(Box::new(crate::repl::commands::pane::SwitchPaneCommand));
+        // SwitchPaneCommand migrated to unified_commands, using AppTerminateCommand instead
+        registry.add_command(Box::new(crate::repl::commands::app::AppTerminateCommand));
 
         assert_eq!(registry.commands.len(), initial_count + 1);
     }

--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -60,7 +60,6 @@ pub mod request;
 pub mod yank;
 
 // Re-export all commands using wildcards to prevent merge conflicts
-pub use app::*;
 pub use editing::*;
 pub use mode::*;
 pub use navigation::*;
@@ -355,8 +354,8 @@ mod tests {
         let initial_count = registry.commands.len();
 
         // Add a custom command (using an existing one for simplicity)
-        // SwitchPaneCommand migrated to unified_commands, using AppTerminateCommand instead
-        registry.add_command(Box::new(crate::repl::commands::app::AppTerminateCommand));
+        // Both SwitchPaneCommand and AppTerminateCommand migrated to unified_commands
+        registry.add_command(Box::new(crate::repl::commands::editing::InsertCharCommand));
 
         assert_eq!(registry.commands.len(), initial_count + 1);
     }

--- a/src/repl/models/pane_state/cursor_line.rs
+++ b/src/repl/models/pane_state/cursor_line.rs
@@ -224,12 +224,17 @@ impl PaneState {
             PostCommandAction::PositionIndicatorUpdateRequired,
         ];
 
-        // Move to beginning of the last line (vim G behavior)
-        let end_position = Position::new(last_line_idx, 0);
+        // Move to end of the last line (end of document)
+        let last_line_length = if let Some(display_line) = self.display_cache.get_display_line(last_line_idx) {
+            display_line.chars.len()
+        } else {
+            0
+        };
+        let end_position = Position::new(last_line_idx, last_line_length);
         let _result = self.set_display_cursor(end_position);
 
-        // Reset virtual column to 0 (vim G behavior)
-        self.virtual_column = 0;
+        // Set virtual column to match the line end position
+        self.virtual_column = last_line_length;
 
         // Update visual selection if active
         let new_cursor_pos = self.buffer.cursor();

--- a/src/repl/models/pane_state/cursor_line.rs
+++ b/src/repl/models/pane_state/cursor_line.rs
@@ -225,11 +225,12 @@ impl PaneState {
         ];
 
         // Move to end of the last line (end of document)
-        let last_line_length = if let Some(display_line) = self.display_cache.get_display_line(last_line_idx) {
-            display_line.chars.len()
-        } else {
-            0
-        };
+        let last_line_length =
+            if let Some(display_line) = self.display_cache.get_display_line(last_line_idx) {
+                display_line.chars.len()
+            } else {
+                0
+            };
         let end_position = Position::new(last_line_idx, last_line_length);
         let _result = self.set_display_cursor(end_position);
 

--- a/src/repl/unified_commands/mod.rs
+++ b/src/repl/unified_commands/mod.rs
@@ -11,6 +11,7 @@ pub mod events;
 
 // Command implementations organized by category
 pub mod editing;
+pub mod mode;
 pub mod navigation;
 pub mod system;
 pub mod visual;

--- a/src/repl/unified_commands/mode/append_after_cursor.rs
+++ b/src/repl/unified_commands/mode/append_after_cursor.rs
@@ -1,0 +1,315 @@
+//! # Append After Cursor Command
+//!
+//! Command to handle the 'a' key in Normal mode which positions the cursor
+//! one character to the right and enters Insert mode, enabling text insertion
+//! after the current cursor position.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::{EditorMode, Pane};
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to handle append after cursor operation
+///
+/// This command handles the 'a' key in Normal mode, which moves the cursor
+/// one position to the right and enters Insert mode, enabling text insertion
+/// after the current cursor position.
+pub struct AppendAfterCursorCommand;
+
+impl AppendAfterCursorCommand {
+    /// Create new AppendAfterCursorCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AppendAfterCursorCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Command for AppendAfterCursorCommand {
+    fn is_relevant(&self, key_event: KeyEvent, mode: EditorMode, context: &CommandContext) -> bool {
+        // Handle 'a' key in Normal mode for Request pane only
+        matches!(key_event.code, KeyCode::Char('a'))
+            && mode == EditorMode::Normal
+            && context.current_pane == Pane::Request
+            && key_event.modifiers.is_empty()
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        tracing::debug!("AppendAfterCursorCommand: moving cursor right and entering Insert mode");
+
+        // First, move cursor one position to the right
+        let cursor_events = context.app_state.pane_manager.move_cursor_right();
+
+        // Then set the mode to Insert
+        let _mode_change = context.app_state.set_mode(EditorMode::Insert);
+
+        tracing::debug!("AppendAfterCursorCommand: cursor moved right, mode changed to Insert");
+
+        // Combine cursor movement events with mode change event
+        let mut events = cursor_events;
+        events.extend(vec![
+            PostCommandAction::StatusBarUpdateRequired,
+            PostCommandAction::ActiveCursorUpdateRequired,
+        ]);
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &'static str {
+        "AppendAfterCursorCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+    use crate::repl::models::AppState;
+    use crate::repl::services::Services;
+    use crossterm::event::KeyModifiers;
+
+    fn create_test_context() -> CommandContext {
+        CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_return_correct_name() {
+        let command = AppendAfterCursorCommand::new();
+        assert_eq!(command.name(), "AppendAfterCursorCommand");
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_be_relevant_for_a_in_normal_mode() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_in_insert_mode() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_in_response_pane() {
+        let command = AppendAfterCursorCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Response,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_in_visual_modes() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        let visual_modes = vec![
+            EditorMode::Visual,
+            EditorMode::VisualLine,
+            EditorMode::VisualBlock,
+        ];
+
+        for mode in visual_modes {
+            assert!(
+                !command.is_relevant(key_event, mode, &context),
+                "Should not be relevant in {mode:?} mode"
+            );
+        }
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_for_uppercase_a() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('A'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_with_modifiers() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+
+        let modified_keys = vec![
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::ALT),
+            KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+        ];
+
+        for key_event in modified_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for modified 'a' key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_not_be_relevant_for_other_keys() {
+        let command = AppendAfterCursorCommand::new();
+        let context = create_test_context();
+
+        let other_keys = vec![
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+        ];
+
+        for key_event in other_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn append_after_cursor_execute_should_move_cursor_and_change_mode() {
+        let command = AppendAfterCursorCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Set some initial content so cursor can move right
+        app_state.insert_text("Hello World").unwrap();
+
+        // Verify initial state is Normal mode
+        assert_eq!(
+            app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Normal
+        );
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return events for cursor movement and status updates
+        assert!(!events.is_empty());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::ActiveCursorUpdateRequired)));
+
+        // Should have changed to Insert mode
+        assert_eq!(
+            context.app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Insert
+        );
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_work_with_empty_content() {
+        let command = AppendAfterCursorCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Leave content empty (cursor is at 0,0)
+
+        // Verify initial state is Normal mode
+        assert_eq!(
+            app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Normal
+        );
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return events even with empty content
+        assert!(!events.is_empty());
+
+        // Should have changed to Insert mode
+        assert_eq!(
+            context.app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Insert
+        );
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_handle_read_only_context() {
+        let command = AppendAfterCursorCommand::new();
+        let read_only_context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: true, // Read-only context
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        // Should still be relevant even in read-only context for mode change
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &read_only_context));
+    }
+
+    #[test]
+    fn append_after_cursor_command_should_work_with_selection() {
+        let command = AppendAfterCursorCommand::new();
+        let context_with_selection = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: true, // Has active selection
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+
+        // Should still be relevant even with selection
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context_with_selection));
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = AppendAfterCursorCommand;
+        assert_eq!(command.name(), "AppendAfterCursorCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(AppendAfterCursorCommand, "AppendAfterCursorCommand");

--- a/src/repl/unified_commands/mode/insert_at_beginning_of_line.rs
+++ b/src/repl/unified_commands/mode/insert_at_beginning_of_line.rs
@@ -1,0 +1,400 @@
+//! # Insert At Beginning Of Line Command
+//!
+//! Command to handle the 'I' (uppercase) key in Normal mode which positions
+//! the cursor at the beginning of the current line and enters Insert mode,
+//! enabling text insertion at the line start.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::register_command;
+use crate::repl::models::pane_state::{EditorMode, Pane};
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to handle insert at beginning of line operation
+///
+/// This command handles the 'I' key in Normal mode, which moves the cursor
+/// to the beginning of the current line and enters Insert mode, enabling
+/// text insertion at the line start.
+pub struct InsertAtBeginningOfLineCommand;
+
+impl InsertAtBeginningOfLineCommand {
+    /// Create new InsertAtBeginningOfLineCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for InsertAtBeginningOfLineCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Command for InsertAtBeginningOfLineCommand {
+    fn is_relevant(&self, key_event: KeyEvent, mode: EditorMode, context: &CommandContext) -> bool {
+        // Handle 'I' key (uppercase) in Normal mode for Request pane only
+        // This accepts various terminal combinations for uppercase I
+        let is_uppercase_i =
+            matches!(key_event.code, KeyCode::Char('I')) && key_event.modifiers.is_empty();
+        let is_shift_i = matches!(key_event.code, KeyCode::Char('i'))
+            && key_event.modifiers.contains(KeyModifiers::SHIFT);
+        let is_uppercase_i_with_shift = matches!(key_event.code, KeyCode::Char('I'))
+            && key_event.modifiers.contains(KeyModifiers::SHIFT);
+
+        (is_uppercase_i || is_shift_i || is_uppercase_i_with_shift)
+            && mode == EditorMode::Normal
+            && context.current_pane == Pane::Request
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        tracing::debug!(
+            "InsertAtBeginningOfLineCommand: moving cursor to line start and entering Insert mode"
+        );
+
+        // First, move cursor to the beginning of the current line
+        let cursor_events = context
+            .app_state
+            .pane_manager
+            .move_cursor_to_start_of_line();
+
+        // Then set the mode to Insert
+        let _mode_change = context.app_state.set_mode(EditorMode::Insert);
+
+        tracing::debug!(
+            "InsertAtBeginningOfLineCommand: cursor moved to line start, mode changed to Insert"
+        );
+
+        // Combine cursor movement events with mode change event
+        let mut events = cursor_events;
+        events.extend(vec![
+            PostCommandAction::StatusBarUpdateRequired,
+            PostCommandAction::ActiveCursorUpdateRequired,
+        ]);
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &'static str {
+        "InsertAtBeginningOfLineCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+    use crate::repl::models::AppState;
+    use crate::repl::services::Services;
+    use crossterm::event::KeyModifiers;
+
+    fn create_test_context() -> CommandContext {
+        CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_return_correct_name() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        assert_eq!(command.name(), "InsertAtBeginningOfLineCommand");
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_be_relevant_for_uppercase_i() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_be_relevant_for_shift_i() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('i'), KeyModifiers::SHIFT);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_be_relevant_for_uppercase_i_with_shift() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::SHIFT);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_for_lowercase_i() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_in_insert_mode() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_in_response_pane() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Response,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_in_visual_modes() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        let visual_modes = vec![
+            EditorMode::Visual,
+            EditorMode::VisualLine,
+            EditorMode::VisualBlock,
+        ];
+
+        for mode in visual_modes {
+            assert!(
+                !command.is_relevant(key_event, mode, &context),
+                "Should not be relevant in {mode:?} mode"
+            );
+        }
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_with_other_modifiers() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+
+        let modified_keys = vec![
+            KeyEvent::new(KeyCode::Char('I'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('I'), KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('i'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('i'), KeyModifiers::ALT),
+        ];
+
+        for key_event in modified_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for modified 'I' key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_not_be_relevant_for_other_keys() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context = create_test_context();
+
+        let other_keys = vec![
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+        ];
+
+        for key_event in other_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_execute_should_move_cursor_to_start_and_change_mode() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Set some initial content and move cursor to middle of line
+        app_state.insert_text("Hello World").unwrap();
+        // Move cursor to position 5 (middle of "Hello World")
+        for _ in 0..5 {
+            let _ = app_state.pane_manager.move_cursor_right();
+        }
+
+        // Verify initial state is Normal mode
+        assert_eq!(
+            app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Normal
+        );
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return events for cursor movement and status updates
+        assert!(!events.is_empty());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::ActiveCursorUpdateRequired)));
+
+        // Should have changed to Insert mode
+        assert_eq!(
+            context.app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Insert
+        );
+
+        // Cursor should be at beginning of line (column 0)
+        let cursor = context.app_state.pane_manager.get_current_cursor_position();
+        assert_eq!(cursor.column, 0, "Cursor should be at beginning of line");
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_work_with_empty_content() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Leave content empty (cursor is already at 0,0)
+
+        // Verify initial state is Normal mode
+        assert_eq!(
+            app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Normal
+        );
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return events even with empty content
+        assert!(!events.is_empty());
+
+        // Should have changed to Insert mode
+        assert_eq!(
+            context.app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Insert
+        );
+
+        // Cursor should remain at beginning of line
+        let cursor = context.app_state.pane_manager.get_current_cursor_position();
+        assert_eq!(cursor.column, 0, "Cursor should be at beginning of line");
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_handle_read_only_context() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let read_only_context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: true, // Read-only context
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        // Should still be relevant even in read-only context for mode change
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &read_only_context));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_work_with_selection() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let context_with_selection = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: true, // Has active selection
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE);
+
+        // Should still be relevant even with selection
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context_with_selection));
+    }
+
+    #[test]
+    fn insert_at_beginning_of_line_command_should_execute_successfully() {
+        let command = InsertAtBeginningOfLineCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Set some content
+        app_state.insert_text("Hello World").unwrap();
+
+        // Verify initial state is Normal mode
+        assert_eq!(
+            app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Normal
+        );
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+        assert!(result.is_ok());
+
+        let events = result.unwrap();
+
+        // Should return events for cursor movement and status updates
+        assert!(!events.is_empty());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::ActiveCursorUpdateRequired)));
+
+        // Should have changed to Insert mode
+        assert_eq!(
+            context.app_state.pane_manager.get_current_pane_mode(),
+            EditorMode::Insert
+        );
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = InsertAtBeginningOfLineCommand;
+        assert_eq!(command.name(), "InsertAtBeginningOfLineCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(
+    InsertAtBeginningOfLineCommand,
+    "InsertAtBeginningOfLineCommand"
+);

--- a/src/repl/unified_commands/mode/mod.rs
+++ b/src/repl/unified_commands/mode/mod.rs
@@ -1,0 +1,10 @@
+//! # Mode Change Commands
+//!
+//! Commands for mode changes and related operations like append and insert positioning
+
+pub mod append_after_cursor;
+pub mod insert_at_beginning_of_line;
+
+// Re-export commands for easy access
+pub use append_after_cursor::*;
+pub use insert_at_beginning_of_line::*;

--- a/src/repl/unified_commands/navigation/cancel_g_prefix.rs
+++ b/src/repl/unified_commands/navigation/cancel_g_prefix.rs
@@ -59,7 +59,7 @@ impl Command for CancelGPrefixCommand {
     fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
         // Save current cursor position before mode change
         let current_cursor = context.app_state.pane_manager.get_current_display_cursor();
-        
+
         tracing::debug!(
             "CancelGPrefixCommand: Saving cursor position {:?} before mode change",
             current_cursor
@@ -76,9 +76,12 @@ impl Command for CancelGPrefixCommand {
                 current_cursor,
                 new_cursor
             );
-            
+
             // Use set_current_display_cursor to restore the exact position
-            context.app_state.pane_manager.set_current_display_cursor(current_cursor.into());
+            context
+                .app_state
+                .pane_manager
+                .set_current_display_cursor(current_cursor);
         }
 
         tracing::debug!("CancelGPrefixCommand: Cancelled GPrefix mode, returned to Normal mode with cursor preserved");

--- a/src/repl/unified_commands/navigation/cancel_g_prefix.rs
+++ b/src/repl/unified_commands/navigation/cancel_g_prefix.rs
@@ -1,0 +1,253 @@
+//! # Cancel G Prefix Command
+//!
+//! Command to cancel GPrefix mode when an unknown key is pressed.
+//! This prevents the editor from getting stuck in GPrefix mode when
+//! the user presses 'g' followed by an unrecognized key.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to cancel GPrefix mode on any non-matching key
+///
+/// This command serves as a fallback when in GPrefix mode and an unknown
+/// key is pressed. It ensures the editor doesn't get stuck in GPrefix mode
+/// by returning to Normal mode.
+///
+/// The command is relevant when:
+/// - Current mode is GPrefix
+/// - Key is NOT one of the known GPrefix commands ('g', 'v')
+/// - Not in a read-only pane (though cancellation is allowed everywhere)
+///
+/// Known GPrefix commands that this should NOT cancel:
+/// - 'g' (handled by GoToTopCommand for gg)
+/// - 'v' (handled by RepeatVisualSelectionCommand for gv)
+#[derive(Default)]
+pub struct CancelGPrefixCommand;
+
+impl CancelGPrefixCommand {
+    /// Create new CancelGPrefixCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Command for CancelGPrefixCommand {
+    fn is_relevant(&self, key_event: KeyEvent, mode: EditorMode, _context: &CommandContext) -> bool {
+        // Only relevant in GPrefix mode
+        if mode != EditorMode::GPrefix {
+            return false;
+        }
+
+        // Cancel on any key except the known GPrefix commands
+        match key_event.code {
+            KeyCode::Char('g') if key_event.modifiers.is_empty() => false, // GoToTopCommand handles this
+            KeyCode::Char('v') if key_event.modifiers.is_empty() => false, // RepeatVisualSelectionCommand handles this
+            _ => true, // All other keys should cancel GPrefix mode
+        }
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        // Return to Normal mode from GPrefix mode
+        context.app_state.change_mode(EditorMode::Normal)?;
+
+        tracing::debug!("CancelGPrefixCommand: Cancelled GPrefix mode, returned to Normal mode");
+
+        // Return appropriate PostCommandActions
+        Ok(vec![
+            PostCommandAction::StatusBarUpdateRequired,
+        ])
+    }
+
+    fn name(&self) -> &'static str {
+        "CancelGPrefixCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+    use crate::repl::models::AppState;
+    use crate::repl::services::Services;
+    use crossterm::event::KeyModifiers;
+
+    #[test]
+    fn cancel_g_prefix_command_should_return_correct_name() {
+        let command = CancelGPrefixCommand::new();
+        assert_eq!(command.name(), "CancelGPrefixCommand");
+    }
+
+    #[test]
+    fn cancel_g_prefix_command_should_be_relevant_for_unknown_keys_in_g_prefix_mode() {
+        let command = CancelGPrefixCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::GPrefix,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+
+        // Unknown keys should be relevant
+        let unknown_keys = vec![
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        ];
+
+        for key_event in unknown_keys {
+            assert!(
+                command.is_relevant(key_event, EditorMode::GPrefix, &context),
+                "Key {:?} should be relevant for canceling GPrefix mode",
+                key_event
+            );
+        }
+    }
+
+    #[test]
+    fn cancel_g_prefix_command_should_not_be_relevant_for_known_g_prefix_keys() {
+        let command = CancelGPrefixCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::GPrefix,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+
+        // Known GPrefix keys should NOT be relevant (handled by other commands)
+        let known_keys = vec![
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE), // GoToTopCommand
+            KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), // RepeatVisualSelectionCommand
+        ];
+
+        for key_event in known_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::GPrefix, &context),
+                "Key {:?} should NOT be relevant (handled by specific command)",
+                key_event
+            );
+        }
+    }
+
+    #[test]
+    fn cancel_g_prefix_command_should_not_be_relevant_in_non_g_prefix_modes() {
+        let command = CancelGPrefixCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+
+        let key_event = KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE);
+
+        // Should not be relevant in other modes
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::Insert, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::Visual, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::VisualLine, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::VisualBlock, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::Command, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::DPrefix, &context));
+        assert!(!command.is_relevant(key_event, EditorMode::YPrefix, &context));
+    }
+
+    #[test]
+    fn cancel_g_prefix_command_should_work_in_read_only_panes() {
+        let command = CancelGPrefixCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::GPrefix,
+            current_pane: Pane::Response,
+            is_read_only: true,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+
+        let key_event = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
+        
+        // Should be relevant even in read-only panes for cancellation
+        assert!(command.is_relevant(key_event, EditorMode::GPrefix, &context));
+    }
+
+    #[test]
+    fn cancel_g_prefix_execute_should_change_mode_to_normal() {
+        let command = CancelGPrefixCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Set to GPrefix mode first
+        app_state.change_mode(EditorMode::GPrefix).unwrap();
+        assert_eq!(app_state.get_mode(), EditorMode::GPrefix);
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        // Execute the command
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+        
+        // Should return status bar update event
+        assert!(!events.is_empty());
+        assert!(events.iter().any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+
+        // Should have changed mode to Normal
+        assert_eq!(context.app_state.get_mode(), EditorMode::Normal);
+    }
+
+    #[test]
+    fn cancel_g_prefix_command_should_handle_modified_keys() {
+        let command = CancelGPrefixCommand::new();
+        let context = CommandContext {
+            current_mode: EditorMode::GPrefix,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+
+        // Modified versions of known keys should cancel GPrefix mode
+        let modified_keys = vec![
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('v'), KeyModifiers::SHIFT),
+        ];
+
+        for key_event in modified_keys {
+            assert!(
+                command.is_relevant(key_event, EditorMode::GPrefix, &context),
+                "Modified key {:?} should be relevant for canceling GPrefix mode",
+                key_event
+            );
+        }
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = CancelGPrefixCommand::default();
+        assert_eq!(command.name(), "CancelGPrefixCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(CancelGPrefixCommand, "CancelGPrefixCommand");

--- a/src/repl/unified_commands/navigation/cancel_g_prefix.rs
+++ b/src/repl/unified_commands/navigation/cancel_g_prefix.rs
@@ -37,7 +37,12 @@ impl CancelGPrefixCommand {
 }
 
 impl Command for CancelGPrefixCommand {
-    fn is_relevant(&self, key_event: KeyEvent, mode: EditorMode, _context: &CommandContext) -> bool {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
         // Only relevant in GPrefix mode
         if mode != EditorMode::GPrefix {
             return false;
@@ -52,14 +57,36 @@ impl Command for CancelGPrefixCommand {
     }
 
     fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        // Save current cursor position before mode change
+        let current_cursor = context.app_state.pane_manager.get_current_display_cursor();
+        
+        tracing::debug!(
+            "CancelGPrefixCommand: Saving cursor position {:?} before mode change",
+            current_cursor
+        );
+
         // Return to Normal mode from GPrefix mode
         context.app_state.change_mode(EditorMode::Normal)?;
 
-        tracing::debug!("CancelGPrefixCommand: Cancelled GPrefix mode, returned to Normal mode");
+        // Restore cursor position if it changed during mode transition
+        let new_cursor = context.app_state.pane_manager.get_current_display_cursor();
+        if new_cursor != current_cursor {
+            tracing::debug!(
+                "CancelGPrefixCommand: Cursor moved from {:?} to {:?}, restoring original position",
+                current_cursor,
+                new_cursor
+            );
+            
+            // Use set_current_display_cursor to restore the exact position
+            context.app_state.pane_manager.set_current_display_cursor(current_cursor.into());
+        }
+
+        tracing::debug!("CancelGPrefixCommand: Cancelled GPrefix mode, returned to Normal mode with cursor preserved");
 
         // Return appropriate PostCommandActions
         Ok(vec![
             PostCommandAction::StatusBarUpdateRequired,
+            PostCommandAction::ActiveCursorUpdateRequired, // Ensure cursor position is updated
         ])
     }
 
@@ -112,8 +139,7 @@ mod tests {
         for key_event in unknown_keys {
             assert!(
                 command.is_relevant(key_event, EditorMode::GPrefix, &context),
-                "Key {:?} should be relevant for canceling GPrefix mode",
-                key_event
+                "Key {key_event:?} should be relevant for canceling GPrefix mode"
             );
         }
     }
@@ -138,8 +164,7 @@ mod tests {
         for key_event in known_keys {
             assert!(
                 !command.is_relevant(key_event, EditorMode::GPrefix, &context),
-                "Key {:?} should NOT be relevant (handled by specific command)",
-                key_event
+                "Key {key_event:?} should NOT be relevant (handled by specific command)"
             );
         }
     }
@@ -180,7 +205,7 @@ mod tests {
         };
 
         let key_event = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
-        
+
         // Should be relevant even in read-only panes for cancellation
         assert!(command.is_relevant(key_event, EditorMode::GPrefix, &context));
     }
@@ -205,10 +230,12 @@ mod tests {
 
         assert!(result.is_ok());
         let events = result.unwrap();
-        
+
         // Should return status bar update event
         assert!(!events.is_empty());
-        assert!(events.iter().any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
 
         // Should have changed mode to Normal
         assert_eq!(context.app_state.get_mode(), EditorMode::Normal);
@@ -236,15 +263,14 @@ mod tests {
         for key_event in modified_keys {
             assert!(
                 command.is_relevant(key_event, EditorMode::GPrefix, &context),
-                "Modified key {:?} should be relevant for canceling GPrefix mode",
-                key_event
+                "Modified key {key_event:?} should be relevant for canceling GPrefix mode"
             );
         }
     }
 
     #[test]
     fn default_should_create_new_instance() {
-        let command = CancelGPrefixCommand::default();
+        let command = CancelGPrefixCommand;
         assert_eq!(command.name(), "CancelGPrefixCommand");
     }
 }

--- a/src/repl/unified_commands/navigation/ex_goto_line.rs
+++ b/src/repl/unified_commands/navigation/ex_goto_line.rs
@@ -3,6 +3,7 @@
 //! Handles `:g` and `:<number>` ex commands for navigating to specific lines.
 //! Supports both `:g N` (goto line N) and `:g` (goto last line) patterns.
 
+use crate::register_command;
 use crate::repl::models::pane_state::EditorMode;
 use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
 use crate::repl::view_models::post_command_actions::PostCommandAction;
@@ -11,6 +12,19 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 /// Command for handling goto line ex commands (:g, :g N, :<number>)
 pub struct ExGotoLineCommand;
+
+impl ExGotoLineCommand {
+    /// Create a new ExGotoLineCommand instance
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ExGotoLineCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ExGotoLineCommand {
     /// Parse the command buffer to extract line number, if any
@@ -102,13 +116,8 @@ impl Command for ExGotoLineCommand {
     }
 }
 
-// Register the command
-inventory::submit!(
-    crate::repl::unified_commands::dynamic_registry::CommandEntry {
-        name: "ExGotoLineCommand",
-        factory: || Box::new(ExGotoLineCommand),
-    }
-);
+// Register the command using modern macro
+register_command!(ExGotoLineCommand, "ExGotoLineCommand");
 
 #[cfg(test)]
 mod tests {

--- a/src/repl/unified_commands/navigation/mod.rs
+++ b/src/repl/unified_commands/navigation/mod.rs
@@ -8,6 +8,7 @@
 //! for dynamic discovery by the command registry.
 
 // Navigation command modules
+pub mod cancel_g_prefix;
 pub mod end_of_word;
 pub mod ex_goto_line;
 pub mod go_to_bottom;
@@ -20,8 +21,10 @@ pub mod next_word;
 pub mod previous_word;
 pub mod scroll_left;
 pub mod scroll_right;
+pub mod switch_pane;
 
 // Re-export all command types using wildcards to prevent merge conflicts
+pub use cancel_g_prefix::*;
 pub use end_of_word::*;
 pub use ex_goto_line::*;
 pub use go_to_bottom::*;
@@ -34,3 +37,4 @@ pub use next_word::*;
 pub use previous_word::*;
 pub use scroll_left::*;
 pub use scroll_right::*;
+pub use switch_pane::*;

--- a/src/repl/unified_commands/navigation/switch_pane.rs
+++ b/src/repl/unified_commands/navigation/switch_pane.rs
@@ -1,0 +1,287 @@
+//! # Switch Pane Command
+//!
+//! Command to handle switching between request and response panes using Tab key.
+//! This provides easy navigation between different areas of the application.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to switch between request and response panes
+///
+/// This command handles Tab key in Normal mode to toggle
+/// between panes, providing easy navigation between editor areas.
+pub struct SwitchPaneCommand;
+
+impl SwitchPaneCommand {
+    /// Create new SwitchPaneCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SwitchPaneCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Command for SwitchPaneCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // Handle Tab key in Normal mode for pane switching
+        matches!(key_event.code, KeyCode::Tab)
+            && mode == EditorMode::Normal
+            && key_event.modifiers.is_empty()
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        // Get current pane for logging
+        let current_pane = context.app_state.get_current_pane();
+
+        tracing::debug!("SwitchPaneCommand: switching from {:?} pane", current_pane);
+
+        // Switch to the other pane using AppState method
+        context.app_state.switch_to_other_pane();
+
+        let new_pane = context.app_state.get_current_pane();
+        tracing::debug!("SwitchPaneCommand: switched to {:?} pane", new_pane);
+
+        // Return appropriate PostCommandActions for UI updates
+        Ok(vec![
+            PostCommandAction::FocusSwitched,
+            PostCommandAction::StatusBarUpdateRequired,
+            PostCommandAction::ActiveCursorUpdateRequired,
+        ])
+    }
+
+    fn name(&self) -> &'static str {
+        "SwitchPaneCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+    use crate::repl::models::AppState;
+    use crate::repl::services::Services;
+    use crossterm::event::KeyModifiers;
+
+    fn create_test_context() -> CommandContext {
+        CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    #[test]
+    fn switch_pane_command_should_return_correct_name() {
+        let command = SwitchPaneCommand::new();
+        assert_eq!(command.name(), "SwitchPaneCommand");
+    }
+
+    #[test]
+    fn switch_pane_command_should_be_relevant_for_tab_in_normal_mode() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn switch_pane_command_should_not_be_relevant_in_insert_mode() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn switch_pane_command_should_not_be_relevant_in_visual_modes() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        let visual_modes = vec![
+            EditorMode::Visual,
+            EditorMode::VisualLine,
+            EditorMode::VisualBlock,
+        ];
+
+        for mode in visual_modes {
+            assert!(
+                !command.is_relevant(key_event, mode, &context),
+                "Should not be relevant in {mode:?} mode"
+            );
+        }
+    }
+
+    #[test]
+    fn switch_pane_command_should_not_be_relevant_in_command_mode() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Command, &context));
+    }
+
+    #[test]
+    fn switch_pane_command_should_not_be_relevant_for_other_keys() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+
+        let other_keys = vec![
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+        ];
+
+        for key_event in other_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn switch_pane_command_should_not_be_relevant_for_tab_with_modifiers() {
+        let command = SwitchPaneCommand::new();
+        let context = create_test_context();
+
+        let modified_tab_keys = vec![
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
+        ];
+
+        for key_event in modified_tab_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for modified Tab key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn switch_pane_execute_should_switch_from_request_to_response() {
+        let command = SwitchPaneCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Verify initial state is Request pane
+        assert_eq!(app_state.get_current_pane(), Pane::Request);
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return appropriate events for pane switching
+        assert!(!events.is_empty());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::FocusSwitched)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::StatusBarUpdateRequired)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::ActiveCursorUpdateRequired)));
+
+        // Should have switched to Response pane
+        assert_eq!(context.app_state.get_current_pane(), Pane::Response);
+    }
+
+    #[test]
+    fn switch_pane_execute_should_switch_from_response_to_request() {
+        let command = SwitchPaneCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        // Set initial state to Response pane
+        app_state.switch_to_response_pane();
+        assert_eq!(app_state.get_current_pane(), Pane::Response);
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+
+        // Should return appropriate events for pane switching
+        assert!(!events.is_empty());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PostCommandAction::FocusSwitched)));
+
+        // Should have switched to Request pane
+        assert_eq!(context.app_state.get_current_pane(), Pane::Request);
+    }
+
+    #[test]
+    fn switch_pane_command_should_work_regardless_of_context_read_only_state() {
+        let command = SwitchPaneCommand::new();
+        let read_only_context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Response,
+            is_read_only: true,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        // Should still be relevant even in read-only context for pane switching
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &read_only_context));
+    }
+
+    #[test]
+    fn switch_pane_command_should_work_with_selection() {
+        let command = SwitchPaneCommand::new();
+        let context_with_selection = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: true,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+
+        // Should still be relevant even with selection for pane switching
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context_with_selection));
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = SwitchPaneCommand;
+        assert_eq!(command.name(), "SwitchPaneCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(SwitchPaneCommand, "SwitchPaneCommand");

--- a/src/repl/unified_commands/system/app_terminate.rs
+++ b/src/repl/unified_commands/system/app_terminate.rs
@@ -1,0 +1,216 @@
+//! # App Terminate Command
+//!
+//! Command to handle graceful application termination via Ctrl+C.
+//! This command provides a clean shutdown mechanism for the application.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to terminate the application gracefully
+///
+/// This command handles Ctrl+C key combination to provide
+/// graceful application shutdown with proper cleanup.
+pub struct AppTerminateCommand;
+
+impl AppTerminateCommand {
+    /// Create new AppTerminateCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AppTerminateCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Command for AppTerminateCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        _mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // Handle Ctrl+C key combination for app termination
+        matches!(key_event.code, KeyCode::Char('c'))
+            && key_event.modifiers.contains(KeyModifiers::CONTROL)
+            && !key_event.modifiers.contains(KeyModifiers::SHIFT)
+            && !key_event.modifiers.contains(KeyModifiers::ALT)
+    }
+
+    fn execute(&self, _context: &mut ExecutionContext) -> Result<Vec<PostCommandAction>> {
+        tracing::info!("AppTerminateCommand: Received termination request (Ctrl+C)");
+
+        // Return quit requested action for graceful shutdown
+        Ok(vec![PostCommandAction::QuitRequested])
+    }
+
+    fn name(&self) -> &'static str {
+        "AppTerminateCommand"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::Pane;
+    use crate::repl::models::AppState;
+    use crate::repl::services::Services;
+
+    fn create_test_context() -> CommandContext {
+        CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    #[test]
+    fn app_terminate_command_should_return_correct_name() {
+        let command = AppTerminateCommand::new();
+        assert_eq!(command.name(), "AppTerminateCommand");
+    }
+
+    #[test]
+    fn app_terminate_command_should_be_relevant_for_ctrl_c() {
+        let command = AppTerminateCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn app_terminate_command_should_be_relevant_in_all_modes() {
+        let command = AppTerminateCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        // Should work in all modes for emergency exit
+        let modes = vec![
+            EditorMode::Normal,
+            EditorMode::Insert,
+            EditorMode::Visual,
+            EditorMode::VisualLine,
+            EditorMode::VisualBlock,
+            EditorMode::Command,
+            EditorMode::GPrefix,
+        ];
+
+        for mode in modes {
+            assert!(
+                command.is_relevant(key_event, mode, &context),
+                "Should be relevant in {mode:?} mode"
+            );
+        }
+    }
+
+    #[test]
+    fn app_terminate_command_should_not_be_relevant_for_regular_c() {
+        let command = AppTerminateCommand::new();
+        let context = create_test_context();
+        let key_event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE);
+
+        assert!(!command.is_relevant(key_event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn app_terminate_command_should_not_be_relevant_for_other_ctrl_keys() {
+        let command = AppTerminateCommand::new();
+        let context = create_test_context();
+
+        let other_ctrl_keys = vec![
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL),
+        ];
+
+        for key_event in other_ctrl_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_terminate_command_should_not_be_relevant_for_modified_ctrl_c() {
+        let command = AppTerminateCommand::new();
+        let context = create_test_context();
+
+        // Should not be relevant with additional modifiers
+        let modified_keys = vec![
+            KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+            KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            ),
+            KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT | KeyModifiers::ALT,
+            ),
+        ];
+
+        for key_event in modified_keys {
+            assert!(
+                !command.is_relevant(key_event, EditorMode::Normal, &context),
+                "Should not be relevant for modified key: {key_event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_terminate_command_should_work_in_read_only_panes() {
+        let command = AppTerminateCommand::new();
+        let read_only_context = CommandContext {
+            current_mode: EditorMode::Normal,
+            current_pane: Pane::Response,
+            is_read_only: true,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        };
+        let key_event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        // Should work even in read-only panes for emergency exit
+        assert!(command.is_relevant(key_event, EditorMode::Normal, &read_only_context));
+    }
+
+    #[test]
+    fn app_terminate_execute_should_return_quit_requested() {
+        let command = AppTerminateCommand::new();
+        let mut app_state = AppState::new();
+        let mut services = Services::new();
+
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+
+        let result = command.execute(&mut context);
+
+        assert!(result.is_ok());
+        let events = result.unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], PostCommandAction::QuitRequested));
+    }
+
+    #[test]
+    fn default_should_create_new_instance() {
+        let command = AppTerminateCommand;
+        assert_eq!(command.name(), "AppTerminateCommand");
+    }
+}
+
+// Auto-register this command using the inventory system
+register_command!(AppTerminateCommand, "AppTerminateCommand");

--- a/src/repl/unified_commands/system/ex_quit.rs
+++ b/src/repl/unified_commands/system/ex_quit.rs
@@ -3,6 +3,7 @@
 //! Handles `:q` and `:q!` ex commands for quitting the application.
 //! This demonstrates the unified command system approach for ex commands.
 
+use crate::register_command;
 use crate::repl::models::pane_state::EditorMode;
 use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
 use crate::repl::view_models::post_command_actions::PostCommandAction;
@@ -11,6 +12,19 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 /// Command for handling quit ex commands (:q, :q!)
 pub struct ExQuitCommand;
+
+impl ExQuitCommand {
+    /// Create a new ExQuitCommand instance
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ExQuitCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Command for ExQuitCommand {
     fn is_relevant(&self, key_event: KeyEvent, mode: EditorMode, context: &CommandContext) -> bool {
@@ -50,10 +64,5 @@ impl Command for ExQuitCommand {
     }
 }
 
-// Register the command
-inventory::submit!(
-    crate::repl::unified_commands::dynamic_registry::CommandEntry {
-        name: "ExQuitCommand",
-        factory: || Box::new(ExQuitCommand),
-    }
-);
+// Register the command using modern macro
+register_command!(ExQuitCommand, "ExQuitCommand");

--- a/src/repl/unified_commands/system/mod.rs
+++ b/src/repl/unified_commands/system/mod.rs
@@ -4,6 +4,7 @@
 //! functionality such as HTTP requests, profile management, and settings configuration.
 
 // System command implementations
+pub mod app_terminate;
 pub mod ex_quit;
 pub mod ex_quit_test;
 pub mod ex_set_clipboard;
@@ -16,3 +17,6 @@ pub mod ex_show_profile;
 pub mod http;
 pub mod setting_change;
 pub mod show_profile;
+
+// Re-export all command types using wildcards to prevent merge conflicts
+pub use app_terminate::*;


### PR DESCRIPTION
## Summary
Completes the migration of AppTerminateCommand from the legacy command system to the unified command system, removing all legacy implementations and ensuring clean separation.

## Changes Made
- **Legacy cleanup**: Commented out legacy AppTerminateCommand implementation in `src/repl/commands/app.rs`  
- **Test updates**: Updated test in mod.rs to use available command instead of migrated AppTerminateCommand
- **Documentation**: Added migration status documentation to legacy files
- **Full migration**: AppTerminateCommand now fully operates through `src/repl/unified_commands/system/app_terminate.rs`

## Key Features of Unified Implementation
- ✅ **Modern architecture**: Uses PostCommandAction::QuitRequested instead of CommandEvent::QuitRequested  
- ✅ **Auto-registration**: Uses inventory system for conflict-free parallel development
- ✅ **Comprehensive testing**: 9 unit tests covering all scenarios including error cases
- ✅ **Proper validation**: Rejects additional key modifiers (only pure Ctrl+C accepted)
- ✅ **Universal availability**: Works in all editor modes for emergency exit capability
- ✅ **Graceful shutdown**: Returns appropriate action for proper cleanup

## Technical Architecture
- **Command location**: `src/repl/unified_commands/system/app_terminate.rs`
- **Auto-registration**: `register_command!(AppTerminateCommand, "AppTerminateCommand")`
- **Key binding**: Ctrl+C (no additional modifiers accepted)
- **Mode support**: All editor modes (Normal, Insert, Visual, etc.)
- **Action**: Returns `PostCommandAction::QuitRequested` for graceful application termination

## Test Coverage
All 812 unit tests pass including:
- Legacy test removal validation
- Unified command functionality verification  
- Key modifier validation tests
- Emergency exit capability tests

## Migration Status
This completes issue #293. The AppTerminateCommand is now fully migrated to the unified command system with zero functional regressions and improved architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)