### PR TITLE
Fix #267 #268: Migrate BeginningOfLineCommand and EndOfLineCommand to unified system

### DIFF
--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -104,8 +104,8 @@ impl CommandRegistry {
             // Box::new(EndOfWordCommand), // Migrated to unified_commands
             // Box::new(NextWordCommand), // Migrated to unified_commands
             // Box::new(PreviousWordCommand), // Migrated to unified_commands
-            Box::new(BeginningOfLineCommand),
-            Box::new(EndOfLineCommand),
+            // Box::new(BeginningOfLineCommand), // Migrated to unified_commands/navigation/beginning_of_line.rs
+            // Box::new(EndOfLineCommand), // Migrated to unified_commands/navigation/end_of_line.rs
             Box::new(HomeKeyCommand),
             Box::new(EndKeyCommand),
             // Mode commands

--- a/src/repl/commands/navigation.rs
+++ b/src/repl/commands/navigation.rs
@@ -291,7 +291,10 @@ impl Command for PreviousWordCommand {
 //     }
 // }
 
-/// Move to beginning of line (0 command)
+// Move to beginning of line (0 command)
+// MIGRATED: This command has been migrated to the unified command system.
+// See: src/repl/unified_commands/navigation/beginning_of_line.rs
+/*
 pub struct BeginningOfLineCommand;
 
 impl Command for BeginningOfLineCommand {
@@ -311,8 +314,12 @@ impl Command for BeginningOfLineCommand {
         "BeginningOfLine"
     }
 }
+*/
 
-/// Move to end of line ($ command)
+// Move to end of line ($ command)
+// MIGRATED: This command has been migrated to the unified command system.
+// See: src/repl/unified_commands/navigation/end_of_line.rs
+/*
 pub struct EndOfLineCommand;
 
 impl Command for EndOfLineCommand {
@@ -330,6 +337,7 @@ impl Command for EndOfLineCommand {
         "EndOfLine"
     }
 }
+*/
 
 /// Move to beginning of line (Home key)
 pub struct HomeKeyCommand;
@@ -837,7 +845,8 @@ mod tests {
     // Tests for BeginningOfLineCommand (0)
     // MIGRATED: These tests moved to unified_commands/navigation/beginning_of_line.rs
 
-    // Tests for EndOfLineCommand ($)
+    // Tests for EndOfLineCommand ($) - MIGRATED to unified_commands
+    /*
     #[test]
     fn end_of_line_should_be_relevant_for_dollar_in_normal_mode() {
         let context = create_test_context(EditorMode::Normal);
@@ -869,6 +878,7 @@ mod tests {
             CommandEvent::cursor_move(MovementDirection::LineEnd)
         );
     }
+    */
 
     // Tests for HomeKeyCommand
     #[test]
@@ -1016,6 +1026,7 @@ mod tests {
     }
     */
 
+    /*
     #[test]
     fn end_of_line_should_be_relevant_for_dollar_in_visual_mode() {
         let context = create_test_context(EditorMode::Visual);
@@ -1024,6 +1035,7 @@ mod tests {
 
         assert!(cmd.is_relevant(&context, &event));
     }
+    */
 
     #[test]
     fn go_to_bottom_should_be_relevant_for_uppercase_g_in_visual_mode() {

--- a/src/repl/unified_commands/navigation/beginning_of_line.rs
+++ b/src/repl/unified_commands/navigation/beginning_of_line.rs
@@ -1,0 +1,281 @@
+//! # Beginning of Line Command
+//!
+//! Command for moving cursor to the beginning of the current line (0 key).
+//! This follows the unified command architecture where the Command owns its
+//! business logic and emits appropriate PostCommandActions.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to move cursor to the beginning of the current line
+///
+/// This command demonstrates the new architecture:
+/// 1. Checks for '0' key in Normal/Visual modes
+/// 2. Calls the pane manager to move cursor to start of line
+/// 3. Emits appropriate PostCommandActions to update the display
+///
+/// Handles Vim-style '0' navigation for moving to column 0.
+pub struct BeginningOfLineCommand;
+
+impl BeginningOfLineCommand {
+    /// Create new BeginningOfLineCommand
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Check if the key event is relevant for moving to beginning of line
+    fn is_beginning_of_line_key(key_event: KeyEvent) -> bool {
+        match key_event.code {
+            // vim-style '0' key without modifiers
+            KeyCode::Char('0') => key_event.modifiers.is_empty(),
+            _ => false,
+        }
+    }
+
+    /// Check if current mode allows line navigation
+    fn is_navigation_mode(mode: EditorMode) -> bool {
+        matches!(
+            mode,
+            EditorMode::Normal
+                | EditorMode::Visual
+                | EditorMode::VisualLine
+                | EditorMode::VisualBlock
+        )
+    }
+}
+
+impl Command for BeginningOfLineCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // Check if it's a beginning of line key and we're in a navigation mode
+        Self::is_beginning_of_line_key(key_event) && Self::is_navigation_mode(mode)
+    }
+
+    fn execute(
+        &self,
+        _key_event: KeyEvent,
+        context: &mut ExecutionContext,
+    ) -> Result<Vec<PostCommandAction>> {
+        // Get the cursor movement events from pane manager
+        let events = context
+            .app_state
+            .pane_manager
+            .move_cursor_to_start_of_line();
+
+        tracing::debug!(
+            "BeginningOfLineCommand executed, generated {} events",
+            events.len()
+        );
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &'static str {
+        "BeginningOfLineCommand"
+    }
+}
+
+impl Default for BeginningOfLineCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    #[test]
+    fn beginning_of_line_command_should_return_correct_name() {
+        let command = BeginningOfLineCommand::new();
+        assert_eq!(command.name(), "BeginningOfLineCommand");
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_be_relevant_for_zero_key_in_normal_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_be_relevant_for_zero_key_in_visual_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::Visual;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_be_relevant_for_zero_key_in_visual_line_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::VisualLine;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_be_relevant_for_zero_key_in_visual_block_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::VisualBlock;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_zero_key_in_insert_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::Insert;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_zero_key_in_command_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::Command;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_zero_key_with_modifiers() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::CONTROL);
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_other_keys() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::empty());
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_zero_key_in_g_prefix_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::GPrefix;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn beginning_of_line_command_should_not_be_relevant_for_zero_key_in_visual_block_insert_mode() {
+        let command = BeginningOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        let mode = EditorMode::VisualBlockInsert;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn is_beginning_of_line_key_should_detect_zero_key() {
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        assert!(BeginningOfLineCommand::is_beginning_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_beginning_of_line_key_should_not_detect_zero_key_with_modifiers() {
+        let key_event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::SHIFT);
+        assert!(!BeginningOfLineCommand::is_beginning_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_beginning_of_line_key_should_not_detect_other_keys() {
+        let key_event = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty());
+        assert!(!BeginningOfLineCommand::is_beginning_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_normal_mode() {
+        assert!(BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::Normal
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_mode() {
+        assert!(BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::Visual
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_line_mode() {
+        assert!(BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::VisualLine
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_block_mode() {
+        assert!(BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::VisualBlock
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_not_detect_insert_mode() {
+        assert!(!BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::Insert
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_not_detect_command_mode() {
+        assert!(!BeginningOfLineCommand::is_navigation_mode(
+            EditorMode::Command
+        ));
+    }
+
+    #[test]
+    fn default_should_create_new_command() {
+        let command = BeginningOfLineCommand;
+        assert_eq!(command.name(), "BeginningOfLineCommand");
+    }
+
+    // Integration test placeholder - will be tested via integration tests
+    #[test]
+    fn beginning_of_line_command_integration_test_placeholder() {
+        // This test serves as a placeholder for integration testing
+        // Integration tests will verify the actual cursor movement behavior
+        let command = BeginningOfLineCommand::new();
+        assert_eq!(command.name(), "BeginningOfLineCommand");
+    }
+}
+
+// Register the command for dynamic discovery
+register_command!(BeginningOfLineCommand, "BeginningOfLineCommand");

--- a/src/repl/unified_commands/navigation/end_of_line.rs
+++ b/src/repl/unified_commands/navigation/end_of_line.rs
@@ -1,0 +1,268 @@
+//! # End of Line Command
+//!
+//! Command for moving cursor to the end of the current line ($ key).
+//! This follows the unified command architecture where the Command owns its
+//! business logic and emits appropriate PostCommandActions.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to move cursor to the end of the current line
+///
+/// This command demonstrates the new architecture:
+/// 1. Checks for '$' key in Normal/Visual modes
+/// 2. Calls the pane manager to move cursor to end of line
+/// 3. Emits appropriate PostCommandActions to update the display
+///
+/// Handles Vim-style '$' navigation for moving to the end of line.
+pub struct EndOfLineCommand;
+
+impl EndOfLineCommand {
+    /// Create new EndOfLineCommand
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Check if the key event is relevant for moving to end of line
+    fn is_end_of_line_key(key_event: KeyEvent) -> bool {
+        match key_event.code {
+            // vim-style '$' key without modifiers
+            KeyCode::Char('$') => key_event.modifiers.is_empty(),
+            _ => false,
+        }
+    }
+
+    /// Check if current mode allows line navigation
+    fn is_navigation_mode(mode: EditorMode) -> bool {
+        matches!(
+            mode,
+            EditorMode::Normal
+                | EditorMode::Visual
+                | EditorMode::VisualLine
+                | EditorMode::VisualBlock
+        )
+    }
+}
+
+impl Command for EndOfLineCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // Check if it's an end of line key and we're in a navigation mode
+        Self::is_end_of_line_key(key_event) && Self::is_navigation_mode(mode)
+    }
+
+    fn execute(
+        &self,
+        _key_event: KeyEvent,
+        context: &mut ExecutionContext,
+    ) -> Result<Vec<PostCommandAction>> {
+        // Get the cursor movement events from pane manager
+        let events = context.app_state.pane_manager.move_cursor_to_end_of_line();
+
+        tracing::debug!(
+            "EndOfLineCommand executed, generated {} events",
+            events.len()
+        );
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &'static str {
+        "EndOfLineCommand"
+    }
+}
+
+impl Default for EndOfLineCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    #[test]
+    fn end_of_line_command_should_return_correct_name() {
+        let command = EndOfLineCommand::new();
+        assert_eq!(command.name(), "EndOfLineCommand");
+    }
+
+    #[test]
+    fn end_of_line_command_should_be_relevant_for_dollar_key_in_normal_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_be_relevant_for_dollar_key_in_visual_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::Visual;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_be_relevant_for_dollar_key_in_visual_line_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::VisualLine;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_be_relevant_for_dollar_key_in_visual_block_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::VisualBlock;
+        let context = CommandContext::test_default();
+
+        assert!(command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_dollar_key_in_insert_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::Insert;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_dollar_key_in_command_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::Command;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_dollar_key_with_modifiers() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::SHIFT);
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_other_keys() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty());
+        let mode = EditorMode::Normal;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_dollar_key_in_g_prefix_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::GPrefix;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn end_of_line_command_should_not_be_relevant_for_dollar_key_in_visual_block_insert_mode() {
+        let command = EndOfLineCommand::new();
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        let mode = EditorMode::VisualBlockInsert;
+        let context = CommandContext::test_default();
+
+        assert!(!command.is_relevant(key_event, mode, &context));
+    }
+
+    #[test]
+    fn is_end_of_line_key_should_detect_dollar_key() {
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::empty());
+        assert!(EndOfLineCommand::is_end_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_end_of_line_key_should_not_detect_dollar_key_with_modifiers() {
+        let key_event = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::CONTROL);
+        assert!(!EndOfLineCommand::is_end_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_end_of_line_key_should_not_detect_other_keys() {
+        let key_event = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty());
+        assert!(!EndOfLineCommand::is_end_of_line_key(key_event));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_normal_mode() {
+        assert!(EndOfLineCommand::is_navigation_mode(EditorMode::Normal));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_mode() {
+        assert!(EndOfLineCommand::is_navigation_mode(EditorMode::Visual));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_line_mode() {
+        assert!(EndOfLineCommand::is_navigation_mode(EditorMode::VisualLine));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_detect_visual_block_mode() {
+        assert!(EndOfLineCommand::is_navigation_mode(
+            EditorMode::VisualBlock
+        ));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_not_detect_insert_mode() {
+        assert!(!EndOfLineCommand::is_navigation_mode(EditorMode::Insert));
+    }
+
+    #[test]
+    fn is_navigation_mode_should_not_detect_command_mode() {
+        assert!(!EndOfLineCommand::is_navigation_mode(EditorMode::Command));
+    }
+
+    #[test]
+    fn default_should_create_new_command() {
+        let command = EndOfLineCommand;
+        assert_eq!(command.name(), "EndOfLineCommand");
+    }
+
+    // Integration test placeholder - will be tested via integration tests
+    #[test]
+    fn end_of_line_command_integration_test_placeholder() {
+        // This test serves as a placeholder for integration testing
+        // Integration tests will verify the actual cursor movement behavior
+        let command = EndOfLineCommand::new();
+        assert_eq!(command.name(), "EndOfLineCommand");
+    }
+}
+
+// Register the command for dynamic discovery
+register_command!(EndOfLineCommand, "EndOfLineCommand");

--- a/src/repl/unified_commands/navigation/mod.rs
+++ b/src/repl/unified_commands/navigation/mod.rs
@@ -8,7 +8,9 @@
 //! here won't cause merge conflicts. Add modules alphabetically to prevent conflicts.
 
 // Navigation command modules
+pub mod beginning_of_line;
 pub mod cancel_g_prefix;
+pub mod end_of_line;
 pub mod end_of_word;
 pub mod ex_goto_line;
 pub mod go_to_bottom;
@@ -25,7 +27,9 @@ pub mod scroll_right;
 pub mod switch_pane;
 
 // Re-export all command types using wildcards to prevent merge conflicts
+pub use beginning_of_line::*;
 pub use cancel_g_prefix::*;
+pub use end_of_line::*;
 pub use end_of_word::*;
 pub use ex_goto_line::*;
 pub use go_to_bottom::*;


### PR DESCRIPTION
## Summary
This PR migrates two critical line navigation commands from the legacy command system to the unified command system:
- BeginningOfLineCommand (issue #267) - '0' key to move to column 0
- EndOfLineCommand (issue #268) - '$' key to move to end of line

## Changes
- Created `src/repl/unified_commands/navigation/beginning_of_line.rs` with comprehensive tests
- Created `src/repl/unified_commands/navigation/end_of_line.rs` with comprehensive tests
- Commented out legacy implementations in `src/repl/commands/navigation.rs`
- Updated registry in `src/repl/commands/mod.rs`
- Uses `register_command!` macro for zero-conflict auto-registration

## Test Plan
- [x] All 40+ new unit tests pass
- [x] '0' key moves cursor to beginning of line in Normal/Visual modes
- [x] '$' key moves cursor to end of line in Normal/Visual modes
- [x] Precheck script passes (cargo fmt + clippy)
- [x] No breaking changes to existing functionality

Fixes #267
Fixes #268

🤖 Generated with [Claude Code](https://claude.ai/code)