### PR TITLE
Fix #269 #270: Migrate HomeKeyCommand and EndKeyCommand to unified system

### DIFF
--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -106,8 +106,10 @@ impl CommandRegistry {
             // Box::new(PreviousWordCommand), // Migrated to unified_commands
             Box::new(BeginningOfLineCommand),
             Box::new(EndOfLineCommand),
-            Box::new(HomeKeyCommand),
-            Box::new(EndKeyCommand),
+            // MIGRATED: HomeKeyCommand moved to unified_commands/navigation/home_key.rs
+            // Box::new(HomeKeyCommand),
+            // MIGRATED: EndKeyCommand moved to unified_commands/navigation/end_key.rs
+            // Box::new(EndKeyCommand),
             // Mode commands
             // Box::new(EnterInsertModeCommand), // Migrated to unified_commands/mode/enter_insert_mode.rs
             // Box::new(EnterVisualModeCommand), // Migrated to unified_commands

--- a/src/repl/commands/navigation.rs
+++ b/src/repl/commands/navigation.rs
@@ -331,41 +331,43 @@ impl Command for EndOfLineCommand {
     }
 }
 
-/// Move to beginning of line (Home key)
-pub struct HomeKeyCommand;
+// MIGRATED: HomeKeyCommand moved to unified_commands/navigation/home_key.rs
+// /// Move to beginning of line (Home key)
+// pub struct HomeKeyCommand;
 
-impl Command for HomeKeyCommand {
-    fn is_relevant(&self, _context: &CommandContext, event: &KeyEvent) -> bool {
-        matches!(event.code, KeyCode::Home) && event.modifiers.is_empty()
-    }
+// impl Command for HomeKeyCommand {
+//     fn is_relevant(&self, _context: &CommandContext, event: &KeyEvent) -> bool {
+//         matches!(event.code, KeyCode::Home) && event.modifiers.is_empty()
+//     }
 
-    fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
-        Ok(vec![CommandEvent::cursor_move(
-            MovementDirection::LineStart,
-        )])
-    }
+//     fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+//         Ok(vec![CommandEvent::cursor_move(
+//             MovementDirection::LineStart,
+//         )])
+//     }
 
-    fn name(&self) -> &'static str {
-        "HomeKey"
-    }
-}
+//     fn name(&self) -> &'static str {
+//         "HomeKey"
+//     }
+// }
 
-/// Move to end of line (End key)
-pub struct EndKeyCommand;
+// MIGRATED: EndKeyCommand moved to unified_commands/navigation/end_key.rs
+// /// Move to end of line (End key)
+// pub struct EndKeyCommand;
 
-impl Command for EndKeyCommand {
-    fn is_relevant(&self, _context: &CommandContext, event: &KeyEvent) -> bool {
-        matches!(event.code, KeyCode::End) && event.modifiers.is_empty()
-    }
+// impl Command for EndKeyCommand {
+//     fn is_relevant(&self, _context: &CommandContext, event: &KeyEvent) -> bool {
+//         matches!(event.code, KeyCode::End) && event.modifiers.is_empty()
+//     }
 
-    fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
-        Ok(vec![CommandEvent::cursor_move(MovementDirection::LineEnd)])
-    }
+//     fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
+//         Ok(vec![CommandEvent::cursor_move(MovementDirection::LineEnd)])
+//     }
 
-    fn name(&self) -> &'static str {
-        "EndKey"
-    }
-}
+//     fn name(&self) -> &'static str {
+//         "EndKey"
+//     }
+// }
 
 /// Page down navigation (Ctrl+f)
 pub struct PageDownCommand;
@@ -870,71 +872,72 @@ mod tests {
         );
     }
 
-    // Tests for HomeKeyCommand
-    #[test]
-    fn home_key_should_be_relevant_for_home_key() {
-        let context = create_test_context(EditorMode::Normal);
-        let cmd = HomeKeyCommand;
-        let event = create_test_key_event(KeyCode::Home);
+    // MIGRATED: HomeKeyCommand and EndKeyCommand tests moved to unified_commands/navigation/
+    // // Tests for HomeKeyCommand
+    // #[test]
+    // fn home_key_should_be_relevant_for_home_key() {
+    //     let context = create_test_context(EditorMode::Normal);
+    //     let cmd = HomeKeyCommand;
+    //     let event = create_test_key_event(KeyCode::Home);
 
-        assert!(cmd.is_relevant(&context, &event));
-    }
+    //     assert!(cmd.is_relevant(&context, &event));
+    // }
 
-    #[test]
-    fn home_key_should_be_relevant_in_insert_mode() {
-        let context = create_test_context(EditorMode::Insert);
-        let cmd = HomeKeyCommand;
-        let event = create_test_key_event(KeyCode::Home);
+    // #[test]
+    // fn home_key_should_be_relevant_in_insert_mode() {
+    //     let context = create_test_context(EditorMode::Insert);
+    //     let cmd = HomeKeyCommand;
+    //     let event = create_test_key_event(KeyCode::Home);
 
-        assert!(cmd.is_relevant(&context, &event));
-    }
+    //     assert!(cmd.is_relevant(&context, &event));
+    // }
 
-    #[test]
-    fn home_key_should_produce_line_start_event() {
-        let context = create_test_context(EditorMode::Normal);
-        let cmd = HomeKeyCommand;
-        let event = create_test_key_event(KeyCode::Home);
+    // #[test]
+    // fn home_key_should_produce_line_start_event() {
+    //     let context = create_test_context(EditorMode::Normal);
+    //     let cmd = HomeKeyCommand;
+    //     let event = create_test_key_event(KeyCode::Home);
 
-        let events = cmd.execute(event, &context).unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(
-            events[0],
-            CommandEvent::cursor_move(MovementDirection::LineStart)
-        );
-    }
+    //     let events = cmd.execute(event, &context).unwrap();
+    //     assert_eq!(events.len(), 1);
+    //     assert_eq!(
+    //         events[0],
+    //         CommandEvent::cursor_move(MovementDirection::LineStart)
+    //     );
+    // }
 
-    // Tests for EndKeyCommand
-    #[test]
-    fn end_key_should_be_relevant_for_end_key() {
-        let context = create_test_context(EditorMode::Normal);
-        let cmd = EndKeyCommand;
-        let event = create_test_key_event(KeyCode::End);
+    // // Tests for EndKeyCommand
+    // #[test]
+    // fn end_key_should_be_relevant_for_end_key() {
+    //     let context = create_test_context(EditorMode::Normal);
+    //     let cmd = EndKeyCommand;
+    //     let event = create_test_key_event(KeyCode::End);
 
-        assert!(cmd.is_relevant(&context, &event));
-    }
+    //     assert!(cmd.is_relevant(&context, &event));
+    // }
 
-    #[test]
-    fn end_key_should_be_relevant_in_insert_mode() {
-        let context = create_test_context(EditorMode::Insert);
-        let cmd = EndKeyCommand;
-        let event = create_test_key_event(KeyCode::End);
+    // #[test]
+    // fn end_key_should_be_relevant_in_insert_mode() {
+    //     let context = create_test_context(EditorMode::Insert);
+    //     let cmd = EndKeyCommand;
+    //     let event = create_test_key_event(KeyCode::End);
 
-        assert!(cmd.is_relevant(&context, &event));
-    }
+    //     assert!(cmd.is_relevant(&context, &event));
+    // }
 
-    #[test]
-    fn end_key_should_produce_line_end_event() {
-        let context = create_test_context(EditorMode::Normal);
-        let cmd = EndKeyCommand;
-        let event = create_test_key_event(KeyCode::End);
+    // #[test]
+    // fn end_key_should_produce_line_end_event() {
+    //     let context = create_test_context(EditorMode::Normal);
+    //     let cmd = EndKeyCommand;
+    //     let event = create_test_key_event(KeyCode::End);
 
-        let events = cmd.execute(event, &context).unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(
-            events[0],
-            CommandEvent::cursor_move(MovementDirection::LineEnd)
-        );
-    }
+    //     let events = cmd.execute(event, &context).unwrap();
+    //     assert_eq!(events.len(), 1);
+    //     assert_eq!(
+    //         events[0],
+    //         CommandEvent::cursor_move(MovementDirection::LineEnd)
+    //     );
+    // }
 
     // Visual mode navigation tests
     #[test]

--- a/src/repl/unified_commands/navigation/end_key.rs
+++ b/src/repl/unified_commands/navigation/end_key.rs
@@ -1,0 +1,276 @@
+//! # End Key Command
+//!
+//! Command to move cursor to end of line (End key functionality).
+//! Works in Normal, Visual, and Insert modes.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to move cursor to end of current line
+///
+/// This command:
+/// 1. Handles End key in Normal, Visual, and Insert modes without modifiers
+/// 2. Uses PaneManager's move_cursor_to_end_of_line() method for business logic
+/// 3. Works in both writable and read-only panes
+/// 4. Supports visual mode selection extension
+pub struct EndKeyCommand;
+
+impl EndKeyCommand {
+    /// Create new EndKeyCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Command for EndKeyCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        _mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // End key works in all modes without any modifiers
+        matches!(key_event.code, KeyCode::End) && key_event.modifiers.is_empty()
+    }
+
+    fn execute(
+        &self,
+        _key_event: KeyEvent,
+        context: &mut ExecutionContext,
+    ) -> Result<Vec<PostCommandAction>> {
+        // Use PaneManager's cursor movement business logic that returns PostCommandActions
+        let actions = context.app_state.pane_manager.move_cursor_to_end_of_line();
+
+        tracing::debug!(
+            "EndKeyCommand executed, generated {} actions",
+            actions.len()
+        );
+
+        Ok(actions)
+    }
+
+    fn name(&self) -> &'static str {
+        "EndKeyCommand"
+    }
+}
+
+impl Default for EndKeyCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::EditorMode;
+    use crate::repl::models::pane_state::Pane;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn create_test_key_event(key_code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(key_code, modifiers)
+    }
+
+    fn create_test_command_context(mode: EditorMode) -> CommandContext {
+        CommandContext {
+            current_mode: mode,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    fn create_execution_context() -> (
+        crate::repl::models::app_state::AppState,
+        crate::repl::services::Services,
+    ) {
+        let app_state = crate::repl::models::app_state::AppState::new();
+        let services = crate::repl::services::Services::new();
+        (app_state, services)
+    }
+
+    #[test]
+    fn end_key_command_should_be_relevant_for_end_key() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_be_relevant_in_insert_mode() {
+        let context = create_test_command_context(EditorMode::Insert);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_be_relevant_in_visual_mode() {
+        let context = create_test_command_context(EditorMode::Visual);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Visual, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_not_be_relevant_with_ctrl_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::CONTROL);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_not_be_relevant_with_shift_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::SHIFT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_not_be_relevant_for_other_keys() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+
+        // Test various non-End keys
+        let test_keys = [
+            KeyCode::Home,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Char('l'),
+            KeyCode::Char('$'),
+        ];
+
+        for key in test_keys {
+            let event = create_test_key_event(key, KeyModifiers::empty());
+            assert!(
+                !cmd.is_relevant(event, EditorMode::Normal, &context),
+                "Command should not be relevant for key: {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn end_key_command_execute_should_return_actions() {
+        let (mut app_state, mut services) = create_execution_context();
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        let result = cmd.execute(event, &mut context);
+        assert!(result.is_ok());
+
+        let actions = result.unwrap();
+        // The exact number of actions depends on implementation,
+        // but it should return at least one action
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn end_key_command_name_should_be_correct() {
+        let cmd = EndKeyCommand::new();
+        assert_eq!(cmd.name(), "EndKeyCommand");
+    }
+
+    #[test]
+    fn end_key_command_should_work_in_command_mode() {
+        let context = create_test_command_context(EditorMode::Command);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Command, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_work_in_visual_line_mode() {
+        let context = create_test_command_context(EditorMode::VisualLine);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::VisualLine, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_work_in_visual_block_mode() {
+        let context = create_test_command_context(EditorMode::VisualBlock);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::VisualBlock, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_not_be_relevant_with_alt_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::ALT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn end_key_command_should_not_be_relevant_with_multiple_modifiers() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let event =
+            create_test_key_event(KeyCode::End, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn end_key_command_execute_should_handle_errors_gracefully() {
+        let (mut app_state, mut services) = create_execution_context();
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+        let cmd = EndKeyCommand::new();
+        let event = create_test_key_event(KeyCode::End, KeyModifiers::empty());
+
+        // Even with potentially problematic state, execute should not panic
+        let result = cmd.execute(event, &mut context);
+
+        // Result should be Ok (even if returning empty actions)
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn end_key_command_default_should_work() {
+        let cmd1 = EndKeyCommand::new();
+        let cmd2 = EndKeyCommand;
+
+        assert_eq!(cmd1.name(), cmd2.name());
+    }
+
+    #[test]
+    fn end_key_command_should_not_interfere_with_vim_dollar_command() {
+        // Ensure End key doesn't conflict with Vim's '$' command
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = EndKeyCommand::new();
+        let dollar_event = create_test_key_event(KeyCode::Char('$'), KeyModifiers::empty());
+
+        assert!(!cmd.is_relevant(dollar_event, EditorMode::Normal, &context));
+    }
+}
+
+// Register the command using the dynamic discovery system
+register_command!(EndKeyCommand, "EndKeyCommand");

--- a/src/repl/unified_commands/navigation/home_key.rs
+++ b/src/repl/unified_commands/navigation/home_key.rs
@@ -1,0 +1,269 @@
+//! # Home Key Command
+//!
+//! Command to move cursor to beginning of line (Home key functionality).
+//! Works in Normal, Visual, and Insert modes.
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::register_command;
+use crate::repl::models::pane_state::EditorMode;
+use crate::repl::unified_commands::{Command, CommandContext, ExecutionContext};
+use crate::repl::view_models::post_command_actions::PostCommandAction;
+
+/// Command to move cursor to beginning of current line
+///
+/// This command:
+/// 1. Handles Home key in Normal, Visual, and Insert modes without modifiers
+/// 2. Uses PaneManager's move_cursor_to_start_of_line() method for business logic
+/// 3. Works in both writable and read-only panes
+/// 4. Supports visual mode selection extension
+pub struct HomeKeyCommand;
+
+impl HomeKeyCommand {
+    /// Create new HomeKeyCommand
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Command for HomeKeyCommand {
+    fn is_relevant(
+        &self,
+        key_event: KeyEvent,
+        _mode: EditorMode,
+        _context: &CommandContext,
+    ) -> bool {
+        // Home key works in all modes without any modifiers
+        matches!(key_event.code, KeyCode::Home) && key_event.modifiers.is_empty()
+    }
+
+    fn execute(
+        &self,
+        _key_event: KeyEvent,
+        context: &mut ExecutionContext,
+    ) -> Result<Vec<PostCommandAction>> {
+        // Use PaneManager's cursor movement business logic that returns PostCommandActions
+        let actions = context
+            .app_state
+            .pane_manager
+            .move_cursor_to_start_of_line();
+
+        tracing::debug!(
+            "HomeKeyCommand executed, generated {} actions",
+            actions.len()
+        );
+
+        Ok(actions)
+    }
+
+    fn name(&self) -> &'static str {
+        "HomeKeyCommand"
+    }
+}
+
+impl Default for HomeKeyCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::models::pane_state::EditorMode;
+    use crate::repl::models::pane_state::Pane;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn create_test_key_event(key_code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(key_code, modifiers)
+    }
+
+    fn create_test_command_context(mode: EditorMode) -> CommandContext {
+        CommandContext {
+            current_mode: mode,
+            current_pane: Pane::Request,
+            is_read_only: false,
+            has_selection: false,
+            ex_command_buffer: String::new(),
+        }
+    }
+
+    fn create_execution_context() -> (
+        crate::repl::models::app_state::AppState,
+        crate::repl::services::Services,
+    ) {
+        let app_state = crate::repl::models::app_state::AppState::new();
+        let services = crate::repl::services::Services::new();
+        (app_state, services)
+    }
+
+    #[test]
+    fn home_key_command_should_be_relevant_for_home_key() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_be_relevant_in_insert_mode() {
+        let context = create_test_command_context(EditorMode::Insert);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Insert, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_be_relevant_in_visual_mode() {
+        let context = create_test_command_context(EditorMode::Visual);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Visual, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_not_be_relevant_with_ctrl_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::CONTROL);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_not_be_relevant_with_shift_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::SHIFT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_not_be_relevant_for_other_keys() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+
+        // Test various non-Home keys
+        let test_keys = [
+            KeyCode::End,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Char('h'),
+            KeyCode::Char('0'),
+        ];
+
+        for key in test_keys {
+            let event = create_test_key_event(key, KeyModifiers::empty());
+            assert!(
+                !cmd.is_relevant(event, EditorMode::Normal, &context),
+                "Command should not be relevant for key: {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn home_key_command_execute_should_return_actions() {
+        let (mut app_state, mut services) = create_execution_context();
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        let result = cmd.execute(event, &mut context);
+        assert!(result.is_ok());
+
+        let actions = result.unwrap();
+        // The exact number of actions depends on implementation,
+        // but it should return at least one action
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn home_key_command_name_should_be_correct() {
+        let cmd = HomeKeyCommand::new();
+        assert_eq!(cmd.name(), "HomeKeyCommand");
+    }
+
+    #[test]
+    fn home_key_command_should_work_in_command_mode() {
+        let context = create_test_command_context(EditorMode::Command);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::Command, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_work_in_visual_line_mode() {
+        let context = create_test_command_context(EditorMode::VisualLine);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::VisualLine, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_work_in_visual_block_mode() {
+        let context = create_test_command_context(EditorMode::VisualBlock);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        assert!(cmd.is_relevant(event, EditorMode::VisualBlock, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_not_be_relevant_with_alt_modifier() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::ALT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn home_key_command_should_not_be_relevant_with_multiple_modifiers() {
+        let context = create_test_command_context(EditorMode::Normal);
+        let cmd = HomeKeyCommand::new();
+        let event =
+            create_test_key_event(KeyCode::Home, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+
+        assert!(!cmd.is_relevant(event, EditorMode::Normal, &context));
+    }
+
+    #[test]
+    fn home_key_command_execute_should_handle_errors_gracefully() {
+        let (mut app_state, mut services) = create_execution_context();
+        let mut context = ExecutionContext {
+            app_state: &mut app_state,
+            services: &mut services,
+        };
+        let cmd = HomeKeyCommand::new();
+        let event = create_test_key_event(KeyCode::Home, KeyModifiers::empty());
+
+        // Even with potentially problematic state, execute should not panic
+        let result = cmd.execute(event, &mut context);
+
+        // Result should be Ok (even if returning empty actions)
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn home_key_command_default_should_work() {
+        let cmd1 = HomeKeyCommand::new();
+        let cmd2 = HomeKeyCommand;
+
+        assert_eq!(cmd1.name(), cmd2.name());
+    }
+}
+
+// Register the command using the dynamic discovery system
+register_command!(HomeKeyCommand, "HomeKeyCommand");

--- a/src/repl/unified_commands/navigation/mod.rs
+++ b/src/repl/unified_commands/navigation/mod.rs
@@ -9,10 +9,12 @@
 
 // Navigation command modules
 pub mod cancel_g_prefix;
+pub mod end_key;
 pub mod end_of_word;
 pub mod ex_goto_line;
 pub mod go_to_bottom;
 pub mod go_to_top;
+pub mod home_key;
 pub mod move_down;
 pub mod move_left;
 pub mod move_right;
@@ -26,10 +28,12 @@ pub mod switch_pane;
 
 // Re-export all command types using wildcards to prevent merge conflicts
 pub use cancel_g_prefix::*;
+pub use end_key::*;
 pub use end_of_word::*;
 pub use ex_goto_line::*;
 pub use go_to_bottom::*;
 pub use go_to_top::*;
+pub use home_key::*;
 pub use move_down::*;
 pub use move_left::*;
 pub use move_right::*;


### PR DESCRIPTION
## Summary
This PR migrates the Home and End key commands from the legacy command system to the unified command system:
- HomeKeyCommand (issue #269) - Home key to move to start of line
- EndKeyCommand (issue #270) - End key to move to end of line

## Changes
- Created `src/repl/unified_commands/navigation/home_key.rs` with 15 comprehensive tests
- Created `src/repl/unified_commands/navigation/end_key.rs` with 16 comprehensive tests
- Commented out legacy implementations in `src/repl/commands/navigation.rs`
- Updated registry in `src/repl/commands/mod.rs`
- Uses `register_command!` macro for zero-conflict auto-registration

## Test Plan
- [x] All 31 new unit tests pass
- [x] Home key moves cursor to beginning of line in all modes
- [x] End key moves cursor to end of line in all modes
- [x] Keys work in Normal, Visual, Insert, Command, VisualLine, and VisualBlock modes
- [x] Modifier keys (Ctrl, Shift, Alt) properly rejected
- [x] Precheck script passes (cargo fmt + clippy)
- [x] No breaking changes to existing functionality

Fixes #269
Fixes #270

🤖 Generated with [Claude Code](https://claude.ai/code)