### PR TITLE
Fix #337: Complete VisualBlockAppendCommand migration to unified system

### DIFF
--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -117,7 +117,7 @@ impl CommandRegistry {
             // Box::new(EnterVisualLineModeCommand), // Migrated to unified_commands
             // Box::new(EnterVisualBlockModeCommand), // Migrated to unified_commands/mode/enter_visual_block_mode.rs
             // Box::new(VisualBlockInsertCommand), // Migrated to unified_commands/visual/visual_block_insert.rs
-            Box::new(VisualBlockAppendCommand),
+            // Box::new(VisualBlockAppendCommand), // Migrated to unified_commands/visual/visual_block_append.rs
             // Box::new(AppendAfterCursorCommand), // Migrated to unified_commands/mode/append_after_cursor.rs
             // Box::new(AppendAtEndOfLineCommand), // Migrated to unified_commands/mode/append_at_end_of_line.rs
             // Box::new(InsertAtBeginningOfLineCommand), // Migrated to unified_commands/mode/insert_at_beginning_of_line.rs

--- a/src/repl/commands/mode.rs
+++ b/src/repl/commands/mode.rs
@@ -386,31 +386,8 @@ impl Command for VisualBlockInsertCommand {
     }
 }
 
-/// Append at end of Visual Block selection (Shift+A in Visual Block mode)
-pub struct VisualBlockAppendCommand;
-
-impl Command for VisualBlockAppendCommand {
-    fn is_relevant(&self, context: &CommandContext, event: &KeyEvent) -> bool {
-        context.state.current_mode == EditorMode::VisualBlock
-            && context.state.current_pane == Pane::Request
-            && (
-                // Case 1: Uppercase 'A' without modifiers
-                (matches!(event.code, KeyCode::Char('A')) && event.modifiers.is_empty())
-                // Case 2: Lowercase 'a' with SHIFT modifier
-                || (matches!(event.code, KeyCode::Char('a')) && event.modifiers.contains(KeyModifiers::SHIFT))
-                // Case 3: Uppercase 'A' with SHIFT modifier (some terminals send this)
-                || (matches!(event.code, KeyCode::Char('A')) && event.modifiers.contains(KeyModifiers::SHIFT))
-            )
-    }
-
-    fn execute(&self, _event: KeyEvent, _context: &CommandContext) -> Result<Vec<CommandEvent>> {
-        Ok(vec![CommandEvent::visual_block_append()])
-    }
-
-    fn name(&self) -> &'static str {
-        "VisualBlockAppend"
-    }
-}
+// MIGRATED: VisualBlockAppendCommand moved to unified_commands/visual/visual_block_append.rs
+// The unified implementation provides the same Shift+A functionality in Visual Block mode with modern architecture
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
Completes the migration of VisualBlockAppendCommand from the legacy command system to the unified command system.

## Changes
- ✅ Remove old `VisualBlockAppendCommand` struct from `src/repl/commands/mode.rs`
- ✅ Comment out old command registration in `src/repl/commands/mod.rs`
- ✅ Add migration comments indicating new location

## Context
This completes the migration that was started in #228. The unified command already exists in `src/repl/unified_commands/visual/visual_block_append.rs` and has been working correctly. This PR removes the final remnants of the old command system implementation.

## Testing
- ✅ Unit tests pass for the unified VisualBlockAppendCommand
- ✅ All visual block related tests pass
- ✅ No functional regressions

## Related Issues
- Fixes #337 
- Completes work started in #228
- Part of #226 (Architecture migration)

🤖 Generated with [Claude Code](https://claude.ai/code)